### PR TITLE
Add scripts for BinUtils, GCC and Newlib for Allegrex

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -29,7 +29,7 @@ jobs:
       if: startsWith( matrix.os[0], 'macOS' )
       run: |
         brew update
-        brew install gettext texinfo bison flex gnu-sed ncurses gsl gmp mpfr
+        brew install gettext texinfo bison flex gnu-sed gsl gmp mpfr
 
     - name: Install in MSYS2
       if: matrix.os[0] == 'windows-latest'
@@ -46,6 +46,19 @@ jobs:
         export PSPDEV=$PWD/pspdev
         export PATH=$PATH:$PSPDEV/bin
         ./toolchain.sh
+    
+    - name: Get short SHA
+      id: slug
+      run: echo "::set-output name=sha8::$(echo ${GITHUB_SHA} | cut -c1-8)"
+    
+    - name: Compress pspdev folder
+      run: |
+        tar -zcvf pspdev.tar.gz pspdev
+    
+    - uses: actions/upload-artifact@v2
+      with:
+        name: pspdev-${{ steps.slug.outputs.sha8 }}-${{ matrix.os[0] }}
+        path: pspdev.tar.gz
 
   build-docker:
     runs-on: ubuntu-latest
@@ -85,22 +98,5 @@ jobs:
     
     - uses: actions/upload-artifact@v2
       with:
-        name: pspdev-${{ steps.slug.outputs.sha8 }}-fedora
+        name: pspdev-${{ steps.slug.outputs.sha8 }}-${{ matrix.os[0] }}
         path: pspdev.tar.gz
-    
-    - name: Rename pspdev.tar.gz file
-      run: |
-        mv pspdev.tar.gz pspdev-fedora.tar.gz
-    - name: Extract tag name
-      if: startsWith(github.ref, 'refs/tags/')
-      id: tag
-      run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
-    
-    - name: Release
-      if: startsWith(github.ref, 'refs/tags/')
-      uses: softprops/action-gh-release@v1
-      with:
-        files: pspdev-fedora.tar.gz
-        tag_name: ${{ steps.tag.outputs.VERSION }}
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -1,0 +1,107 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+  repository_dispatch:
+    types: [run_build]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os[0] }}
+    strategy:
+      matrix:
+        os: [[macos-latest, bash], [macOS-11, bash], [ubuntu-latest, bash]]
+    defaults:
+     run:
+      shell: ${{ matrix.os[1] }} {0}
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install on Ubuntu
+      if: matrix.os[0] == 'ubuntu-latest'
+      run: |
+        sudo apt-get update
+        sudo apt-get -y install gettext texinfo bison flex libncurses5-dev libgmp3-dev libmpfr-dev libmpc-dev
+
+    - name: Install on Mac
+      if: startsWith( matrix.os[0], 'macOS' )
+      run: |
+        brew update
+        brew install gettext texinfo bison flex gnu-sed ncurses gsl gmp mpfr
+
+    # For the future, once we support Windows    
+    # - name: Install on MSYS2
+    #   if: matrix.os[0] == 'windows-latest'
+    #   uses: msys2/setup-msys2@v2
+    #   with:
+    #     msystem: MINGW32
+    #     install: base-devel git make texinfo flex bison patch binutils mingw-w64-i686-gcc mingw-w64-x86_64-dlfcn mpc-devel
+    #     update: true
+    #     shell: msys2 {0}
+
+    - name: Runs all stages
+      run: |
+        export PATH="/usr/local/opt/gnu-sed/libexec/gnubin:$PATH"
+        export PSPDEV=$PWD/pspdev
+        export PATH=$PATH:$PSPDEV/bin
+        ./toolchain.sh
+
+  build-docker:
+    runs-on: ubuntu-latest
+    container: ${{ matrix.os[0] }}:latest
+    strategy:
+      matrix:
+        os: [[ubuntu, bash], [fedora, bash]]
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install dependencies Ubuntu
+      if: matrix.os[0] == 'ubuntu'
+      run: |
+        apt-get -y update
+        DEBIAN_FRONTEND="noninteractive" TZ="Europe/London" apt-get -y install file bison make flex texinfo gettext \
+          g++ gcc git libgmp3-dev libmpfr-dev libmpc-dev libncurses5-dev
+    
+    - name: Install dependencies Fedora
+      if: matrix.os[0] == 'fedora'
+      run: |
+        dnf -y install gcc gcc-c++ make git gettext texinfo bison flex gmp-devel mpfr-devel libmpc-devel \
+          ncurses-devel diffutils
+        
+    - name: Runs all the stages in the shell
+      run: |
+        export PSPDEV=$PWD/pspdev
+        export PATH=$PATH:$PSPDEV/bin
+        ./toolchain.sh
+        
+    - name: Get short SHA
+      id: slug
+      run: echo "::set-output name=sha8::$(echo ${GITHUB_SHA} | cut -c1-8)"
+    
+    - name: Compress pspdev folder
+      run: |
+        tar -zcvf pspdev.tar.gz pspdev
+    
+    - uses: actions/upload-artifact@v2
+      with:
+        name: pspdev-${{ steps.slug.outputs.sha8 }}-fedora
+        path: pspdev.tar.gz
+    
+    - name: Rename pspdev.tar.gz file
+      run: |
+        mv pspdev.tar.gz pspdev-fedora.tar.gz
+    - name: Extract tag name
+      if: startsWith(github.ref, 'refs/tags/')
+      id: tag
+      run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+    
+    - name: Release
+      if: startsWith(github.ref, 'refs/tags/')
+      uses: softprops/action-gh-release@v1
+      with:
+        files: pspdev-fedora.tar.gz
+        tag_name: ${{ steps.tag.outputs.VERSION }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os[0] }}
     strategy:
       matrix:
-        os: [[macos-latest, bash], [macOS-11, bash], [ubuntu-latest, bash]]
+        os: [[macos-latest, bash], [macOS-11, bash], [ubuntu-latest, bash], [windows-latest, msys2]]
     defaults:
      run:
       shell: ${{ matrix.os[1] }} {0}
@@ -31,15 +31,14 @@ jobs:
         brew update
         brew install gettext texinfo bison flex gnu-sed ncurses gsl gmp mpfr
 
-    # For the future, once we support Windows    
-    # - name: Install on MSYS2
-    #   if: matrix.os[0] == 'windows-latest'
-    #   uses: msys2/setup-msys2@v2
-    #   with:
-    #     msystem: MINGW32
-    #     install: base-devel git make texinfo flex bison patch binutils mingw-w64-i686-gcc mingw-w64-x86_64-dlfcn mpc-devel
-    #     update: true
-    #     shell: msys2 {0}
+    - name: Install in MSYS2
+      if: matrix.os[0] == 'windows-latest'
+      uses: msys2/setup-msys2@v2
+      with:
+        msystem: MINGW32
+        install: base-devel git make texinfo flex bison patch binutils mingw-w64-i686-gcc mingw-w64-i686-dlfcn mingw-w64-x86_64-dlfcn mpc-devel
+        update: true
+        shell: msys2 {0}
 
     - name: Runs all stages
       run: |

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -36,7 +36,7 @@ jobs:
       uses: msys2/setup-msys2@v2
       with:
         msystem: MINGW32
-        install: base-devel git make texinfo flex bison patch binutils mingw-w64-i686-gcc mingw-w64-i686-dlfcn mingw-w64-x86_64-dlfcn mpc-devel
+        install: base-devel git make texinfo flex bison patch binutils mingw-w64-i686-gcc mingw-w64-i686-dlfcn mingw-w64-i686-mpc
         update: true
         shell: msys2 {0}
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,55 @@
+name: CI-Docker
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - v*
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+  
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Extract DOCKER_TAG using tag name
+      if: startsWith(github.ref, 'refs/tags/')
+      run: |
+        echo "DOCKER_TAG=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+    
+    - name: Use default DOCKER_TAG
+      if: startsWith(github.ref, 'refs/tags/') != true
+      run: |
+        echo "DOCKER_TAG=latest" >> $GITHUB_ENV
+    
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+      
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+      
+    - name: Login to Github registry
+      uses: docker/login-action@v1 
+      with:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+        registry: ghcr.io
+    
+    - uses: docker/build-push-action@v2
+      with:
+        push: true
+        tags: ghcr.io/${{ github.repository }}:${{ env.DOCKER_TAG }}
+    
+    - name: Send Compile action
+      run: |
+        export DISPATCH_ACTION="$(echo run_build)"
+        echo "NEW_DISPATCH_ACTION=$DISPATCH_ACTION" >> $GITHUB_ENV
+
+    - name: Repository Dispatch
+      uses: peter-evans/repository-dispatch@v1
+      with:
+        repository: ${{ github.repository_owner }}/psptoolchain
+        token: ${{ secrets.DISPATCH_TOKEN }}
+        event-type: ${{ env.NEW_DISPATCH_ACTION }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/build/
+/pspdev/
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+# First stage
+FROM alpine:latest
+
+ENV PSPDEV /usr/local/pspdev
+ENV PATH $PATH:${PSPDEV}/bin
+COPY . /src
+
+
+RUN apk add build-base bash gcc git make flex bison texinfo gmp-dev mpfr-dev mpc1-dev readline-dev ncurses-dev
+RUN mkdir $PSPDEV
+RUN cd /src && ./toolchain.sh
+
+# Second stage
+FROM alpine:latest
+
+ENV PSPDEV /usr/local/pspdev
+ENV PATH $PATH:${PSPDEV}/bin
+
+COPY --from=0 ${PSPDEV} ${PSPDEV}

--- a/README.md
+++ b/README.md
@@ -1,95 +1,62 @@
+# psptoolchain-allegrex
+
 [![GitHub Workflow Status](https://img.shields.io/github/workflow/status/pspdev/psptoolchain-allegrex/CI?label=CI&logo=github&style=for-the-badge)](https://github.com/pspdev/psptoolchain-allegrex/actions?query=workflow%3ACI)
 [![GitHub Workflow Status](https://img.shields.io/github/workflow/status/pspdev/psptoolchain-allegrex/CI-Docker?label=CI-Docker&logo=github&style=for-the-badge)](https://github.com/pspdev/psptoolchain-allegrex/actions?query=workflow%3ACI-Docker)
 
-What does this do?
-==================
+This program will automatically build and install a compiler and other tools used in the creation of homebrew software for the Sony Playstation Portable handheld videogame system.
 
-This program will automatically build and install a compiler and other tools
-used in the creation of homebrew software for the Sony Playstation Portable
-handheld videogame system.
+## **ATENTION!**
 
-How do I use it?
-==================
+If you're trying to install in your machine the **WHOLE PSP Development Environment** this is **NOT** the repo to use, you should use instead the [pspdev](https://github.com/pspdev/pspdev "pspdev") repo.
 
-1. Set up your environment by installing the following software:
+## What these scripts do
 
-        bison, diffutils, flex, g++/gcc-c++, gcc, git, libusb-dev, m4, make, 
-        ncurses, readline, texinfo
+These scripts download (`git clone`) and install:
 
-2. Set the PSPDEV and PATH environmental variables:
+-   [binutils](https://github.com/pspdev/binutils-gdb "binutils")
+-   [gdb](https://github.com/pspdev/binutils-gdb "gdb")
+-   [gcc](https://github.com/pspdev/gcc "gcc")
+-   [newlib](https://github.com/pspdev/newlib "newlib")
 
-    ```shell
-    export PSPDEV=/usr/local/pspdev
-    export PATH=$PATH:$PSPDEV/bin
-    ```
+## Requirements
 
-    The PSPDEV variable is the directory the toolchain will be installed to,
-    change this if you wish. If possible the toolchain script will automatically
-    add these variables to your systems login scripts, otherwise you will need
-    to manually add these variables yourself.
+1.  Install gcc/clang, make, cmake, patch, git, texinfo, flex, bison, gettext, wget, gsl, gmp, mpfr, mpc, readline, libarchive, gpgme, bash, openssl and libtool if you don't have those.
+We offer a script to help you for installing dependencies:
 
-3. Run the toolchain script:
-    ```shell
-    ./toolchain.sh
-    ```
-
-> NOTE: If you have issues with compiling try increasing the amount of
-        memory available to your system by creating a swapfile.
-
-```shell
-dd if=/dev/zero of=/swapfile bs=1M count=2048
-chmod 600 /swapfile
-mkswap /swapfile
-swapon /swapfile
-[...compilation...]
-swapoff /swapfile
-rm /swapfile
+### Ubuntu/Debian
+```bash
+sudo ./prepare-debian-ubuntu.sh
 ```
 
-Ubuntu/Debian
--------------
+### Fedora
+```bash
+sudo ./prepare-fedora.sh
+```
 
-1. Install the required packages by running:
-
-        sudo ./prepare-debian-ubuntu.sh
-
-2. Build and install the toolchain and SDK.
-
-        sudo ./toolchain-sudo.sh
- 
-    > NOTE: If you do not wish for the toolchain to be installed in
-            `/usr/local/pspdev` then edit toolchain-sudo.sh and change the
-            `$INSTALLDIR` variable.
-
-OSX
----
-
-1. Install [MacPorts][MacPorts] or [Homebrew][Homebrew].
-2. Install all the libraries you will need before building by running:
-        
-        sudo ./prepare-mac-os.sh
-
-    > NOTE: You can use `-b` or `--brew` flag for using Homebrew and
-            `-p` or `--port` flag for using MacPorts.
-
-3. Build and install the toolchain and SDK.
-        
-        sudo ./toolchain-sudo.sh
-
-Where do I go from here?
-========================
-
-Visit the following sites to learn more:
-
-[PSP-DEV Wiki](https://psp-dev.org/)
-
-[PSP Homebrew Community Discord](https://discord.gg/bePrj9W)
-
+### OSX
+```bash
+sudo ./prepare-mac-os.sh
+```
 [MacPorts]: http://www.macports.org/
 [HomeBrew]: http://brew.sh/
 
-Know Bugs
-==========
-1. Binutils and/or gdb could fail randomly in the installation (an upgrade of the binutls is needed):
-`https://sourceware.org/bugzilla/show_bug.cgi?id=22941`
-So for "fix" the error temporally, some commits from Binutils and GCC (from 2020) have been cherry picked to the allegrex specific branches in the pspdev forks.
+2.  Ensure that you have enough permissions for managing PSPDEV location (default to `/usr/local/pspdev`, but you can use a different path). PSPDEV location MUST NOT have spaces or special characters in its path! PSPDEV should be an absolute path. On Unix systems, if the command `mkdir -p $PSPDEV` fails for you, you can set access for the current user by running commands:
+```bash
+export PSPDEV=/usr/local/pspdev
+sudo mkdir -p $PSPDEV
+sudo chown -R $USER: $PSPDEV
+```
+
+3.  Add this to your login script (example: `~/.bash_profile`)
+    **Note:** Ensure that you have full access to the PSPDEV path. You can change the PSPDEV path with the following requirements: only use absolute paths, don't use spaces, only use Latin characters.
+```bash
+export PSPDEV=/usr/local/pspdev
+export PATH=$PATH:$PSPDEV/bin
+```
+
+4.  Run toolchain.sh
+```bash
+./toolchain.sh
+```
+
+## Thanks

--- a/README.md
+++ b/README.md
@@ -87,3 +87,9 @@ Visit the following sites to learn more:
 
 [MacPorts]: http://www.macports.org/
 [HomeBrew]: http://brew.sh/
+
+Know Bugs
+==========
+1. Binutils and/or gdb could fail randomly in the installation (an upgrade of the binutls is needed):
+`https://sourceware.org/bugzilla/show_bug.cgi?id=22941`
+So for "fix" the error temporally, some commits from Binutils and GCC (from 2020) have been cherry picked to the allegrex specific branches in the pspdev forks.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,87 @@
+What does this do?
+==================
+
+This program will automatically build and install a compiler and other tools
+used in the creation of homebrew software for the Sony Playstation Portable
+handheld videogame system.
+
+How do I use it?
+==================
+
+1. Set up your environment by installing the following software:
+
+        autoconf, automake, bison, bzip2, cmake, doxygen, diffutils, flex,
+        g++/gcc-c++, gcc, git, gzip, libarchive, libcurl, libelf, libgpgme,
+        libssl, libtool, libusb-dev, m4, make, ncurses, patch, pkg-config,
+        python3, readline, subversion, tar, tcl, texinfo, unzip, wget, xz-utils
+
+2. Set the PSPDEV and PATH environmental variables:
+
+    ```shell
+    export PSPDEV=/usr/local/pspdev
+    export PATH=$PATH:$PSPDEV/bin
+    ```
+
+    The PSPDEV variable is the directory the toolchain will be installed to,
+    change this if you wish. If possible the toolchain script will automatically
+    add these variables to your systems login scripts, otherwise you will need
+    to manually add these variables yourself.
+
+3. Run the toolchain script:
+
+        ./toolchain.sh
+
+> NOTE: If you have issues with compiling try increasing the amount of
+        memory available to your system by creating a swapfile.
+
+```shell
+dd if=/dev/zero of=/swapfile bs=1M count=2048
+chmod 600 /swapfile
+mkswap /swapfile
+swapon /swapfile
+[...compilation...]
+swapoff /swapfile
+rm /swapfile
+```
+
+Ubuntu/Debian
+-------------
+
+1. Install the required packages by running:
+
+        sudo ./prepare-debian-ubuntu.sh
+
+2. Build and install the toolchain and SDK.
+
+        sudo ./toolchain-sudo.sh
+ 
+    > NOTE: If you do not wish for the toolchain to be installed in
+            `/usr/local/pspdev` then edit toolchain-sudo.sh and change the
+            `$INSTALLDIR` variable.
+
+OSX
+---
+
+1. Install [MacPorts][MacPorts] or [Homebrew][Homebrew].
+2. Install all the libraries you will need before building by running:
+        
+        sudo ./prepare-mac-os.sh
+
+    > NOTE: You can use `-b` or `--brew` flag for using Homebrew and
+            `-p` or `--port` flag for using MacPorts.
+
+3. Build and install the toolchain and SDK.
+        
+        sudo ./toolchain-sudo.sh
+
+Where do I go from here?
+========================
+
+Visit the following sites to learn more:
+
+[PSP-DEV Wiki](https://psp-dev.org/)
+
+[PSP Homebrew Community Discord](https://discord.gg/bePrj9W)
+
+[MacPorts]: http://www.macports.org/
+[HomeBrew]: http://brew.sh/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 [![GitHub Workflow Status](https://img.shields.io/github/workflow/status/pspdev/psptoolchain-allegrex/CI?label=CI&logo=github&style=for-the-badge)](https://github.com/pspdev/psptoolchain-allegrex/actions?query=workflow%3ACI)
 [![GitHub Workflow Status](https://img.shields.io/github/workflow/status/pspdev/psptoolchain-allegrex/CI-Docker?label=CI-Docker&logo=github&style=for-the-badge)](https://github.com/pspdev/psptoolchain-allegrex/actions?query=workflow%3ACI-Docker)
-[![Docker Pulls](https://img.shields.io/docker/pulls/pspdev/psptoolchain-allegrex?style=for-the-badge)](https://hub.docker.com/r/pspdev/psptoolchain-allegrex/tags)
 
 What does this do?
 ==================
@@ -14,10 +13,8 @@ How do I use it?
 
 1. Set up your environment by installing the following software:
 
-        autoconf, automake, bison, bzip2, cmake, doxygen, diffutils, flex,
-        g++/gcc-c++, gcc, git, gzip, libarchive, libcurl, libelf, libgpgme,
-        libssl, libtool, libusb-dev, m4, make, ncurses, patch, pkg-config,
-        python3, readline, subversion, tar, tcl, texinfo, unzip, wget, xz-utils
+        bison, diffutils, flex, g++/gcc-c++, gcc, git, libusb-dev, m4, make, 
+        ncurses, readline, texinfo
 
 2. Set the PSPDEV and PATH environmental variables:
 
@@ -32,8 +29,9 @@ How do I use it?
     to manually add these variables yourself.
 
 3. Run the toolchain script:
-
-        ./toolchain.sh
+    ```shell
+    ./toolchain.sh
+    ```
 
 > NOTE: If you have issues with compiling try increasing the amount of
         memory available to your system by creating a swapfile.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+[![GitHub Workflow Status](https://img.shields.io/github/workflow/status/pspdev/psptoolchain-allegrex/CI?label=CI&logo=github&style=for-the-badge)](https://github.com/pspdev/psptoolchain-allegrex/actions?query=workflow%3ACI)
+[![GitHub Workflow Status](https://img.shields.io/github/workflow/status/pspdev/psptoolchain-allegrex/CI-Docker?label=CI-Docker&logo=github&style=for-the-badge)](https://github.com/pspdev/psptoolchain-allegrex/actions?query=workflow%3ACI-Docker)
+[![Docker Pulls](https://img.shields.io/docker/pulls/pspdev/psptoolchain-allegrex?style=for-the-badge)](https://hub.docker.com/r/pspdev/psptoolchain-allegrex/tags)
+
 What does this do?
 ==================
 

--- a/depends/check-dependencies.sh
+++ b/depends/check-dependencies.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+header_paths=(
+    "/usr/include" \
+    "/usr/local/include" \
+    "/opt/include" \
+    "/opt/local/include" \
+    "/usr/include/$(uname -m)-linux-gnu" \
+    "/usr/local/include/$(uname -m)-linux-gnu" \
+    "/usr/include/i386-linux-gnu" \
+    "/usr/local/include/i386-linux-gnu"
+    # -- Add more locations here --
+)
+
+missing_depends=()
+
+function check_header
+{
+    for place in ${header_paths[@]}; do
+        for name in ${@:2}; do
+            [ -f "$place/$name" ] && return 0
+        done
+    done
+    
+    missing_depends+=($1); return 1
+}
+
+function check_header_nosys
+{
+    for place in ${header_paths[@]}; do
+        if [ "${place:0:12}" != "/usr/include" ]; then
+            for name in ${@:2}; do
+                [ -f "$place/$name" ] && return 0
+            done
+        fi
+    done
+
+    missing_depends+=($1); return 1
+}
+
+function check_program
+{
+    binary=${2:-$1}
+    for place in ${PATH//:/ }; do
+        [ -x "$place/$binary" ] || [ -x "$place/$binary.exe" ] && return 0
+    done
+    
+    missing_depends+=($1); return 1
+}
+
+# macOS catalina does not ship headers in default directory anymore
+if [ "$(uname)" == "Darwin" ]; then
+  header_paths+=("`xcrun --show-sdk-path`/usr/include")
+fi
+
+check_header    ncurses         ncurses.h ncurses/ncurses.h
+
+check_program   git
+
+check_program   make
+check_program   gcc
+check_program   g++
+
+check_program   bison
+check_program   flex
+
+if [ ${#missing_depends[@]} -ne 0 ]; then
+    echo "Couldn't find dependencies:"
+    for dep in "${missing_depends[@]}"; do
+        echo "  - $dep"
+    done
+	exit 1
+fi

--- a/depends/check-dependencies.sh
+++ b/depends/check-dependencies.sh
@@ -54,7 +54,9 @@ if [ "$(uname)" == "Darwin" ]; then
   header_paths+=("`xcrun --show-sdk-path`/usr/include")
 fi
 
-# check_header    ncurses         ncurses.h ncurses/ncurses.h
+if [ ${OSVER:0:5} == Linux ]; then
+check_header    ncurses         ncurses.h ncurses/ncurses.h
+fi
 
 check_program   git
 
@@ -64,6 +66,10 @@ check_program   g++
 
 check_program   bison
 check_program   flex
+
+if [ -n "$(uname -a | grep Fedora)" ]; then
+    check_program   cmp
+fi
 
 if [ ${#missing_depends[@]} -ne 0 ]; then
     echo "Couldn't find dependencies:"

--- a/depends/check-dependencies.sh
+++ b/depends/check-dependencies.sh
@@ -9,6 +9,7 @@ header_paths=(
     "/usr/local/include/$(uname -m)-linux-gnu" \
     "/usr/include/i386-linux-gnu" \
     "/usr/local/include/i386-linux-gnu"
+    "/mingw32/include/"
     # -- Add more locations here --
 )
 
@@ -53,7 +54,7 @@ if [ "$(uname)" == "Darwin" ]; then
   header_paths+=("`xcrun --show-sdk-path`/usr/include")
 fi
 
-check_header    ncurses         ncurses.h ncurses/ncurses.h
+# check_header    ncurses         ncurses.h ncurses/ncurses.h
 
 check_program   git
 

--- a/depends/check-dependencies.sh
+++ b/depends/check-dependencies.sh
@@ -8,7 +8,7 @@ header_paths=(
     "/usr/include/$(uname -m)-linux-gnu" \
     "/usr/local/include/$(uname -m)-linux-gnu" \
     "/usr/include/i386-linux-gnu" \
-    "/usr/local/include/i386-linux-gnu"
+    "/usr/local/include/i386-linux-gnu" \
     "/mingw32/include/"
     # -- Add more locations here --
 )
@@ -54,6 +54,7 @@ if [ "$(uname)" == "Darwin" ]; then
   header_paths+=("`xcrun --show-sdk-path`/usr/include")
 fi
 
+OSVER=$(uname)
 if [ ${OSVER:0:5} == Linux ]; then
 check_header    ncurses         ncurses.h ncurses/ncurses.h
 fi

--- a/depends/check-pspdev.sh
+++ b/depends/check-pspdev.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+# check-pspdev.sh by Naomi Peori (naomi@peori.ca)
+
+## Check if $PSPDEV is set.
+if test ! $PSPDEV; then { echo "ERROR: Set \$PSPDEV before continuing."; exit 1; } fi
+
+## Check for the $PSPDEV directory.
+ls -ld $PSPDEV > /dev/null 2>&1 || mkdir -p $PSPDEV > /dev/null 2>&1 || { echo "ERROR: Create $PSPDEV before continuing."; exit 1; }
+
+## Check for write permission.
+touch $PSPDEV/test.tmp > /dev/null 2>&1 || { echo "ERROR: Grant write permissions for $PSPDEV before continuing."; exit 1; }
+
+## Check for $PSPDEV/bin in the path.
+echo $PATH | grep $PSPDEV/bin > /dev/null 2>&1 || { echo "ERROR: Add $PSPDEV/bin to your path before continuing."; exit 1; }
+

--- a/depends/check-sh-is-not-dash.sh
+++ b/depends/check-sh-is-not-dash.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+SH_PATH=$(which sh)
+if ls -l $SH_PATH|grep dash >/dev/null 2>&1; then
+    echo "--------------------------------------------------------------------------------"
+    echo "ERROR: $SH_PATH is a symlink to dash!"
+    echo ""
+    echo "This does not go well with libtool, and will make compilation of some packages"
+    echo "from psplibraries fail to compile."
+    echo ""
+    echo "On Debian-derived distros (including Ubuntu), the following will disable dash,"
+    echo "and make $SH_PATH fall back to bash:"
+    echo ""
+    echo '$ echo "dash dash/sh boolean false"|sudo debconf-set-selections'
+    echo '$ sudo dpkg-reconfigure --frontend=noninteractive dash'
+    echo ""
+    echo "Replace 'boolean false' with 'boolean true' if you want to go back to dash."
+    echo ""
+    echo "The reason why dash is the default on some systems is that letting bash provide"
+    echo "$SH_PATH makes all shell scripts start up slightly slower."
+    echo "--------------------------------------------------------------------------------"
+fi

--- a/prepare-debian-ubuntu.sh
+++ b/prepare-debian-ubuntu.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# Install build dependencies
+sudo apt-get install $@ \
+  file bison make flex texinfo gettext g++ gcc git libgmp3-dev libmpfr-dev libmpc-dev libncurses5-dev

--- a/prepare-fedora.sh
+++ b/prepare-fedora.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Install build dependencies
+sudo dnf install $@ \
+  gcc gcc-c++ make git gettext texinfo bison flex gmp-devel mpfr-devel libmpc-devel \
+  ncurses-devel diffutils

--- a/prepare-mac-os.sh
+++ b/prepare-mac-os.sh
@@ -47,10 +47,10 @@ fi
 # actual installation
 if [ $try_brew -eq 1 ]; then
 	CURRENT_USER=$(stat -f '%Su' /dev/console)
-	sudo -u $CURRENT_USER brew install autoconf automake cmake gnu-sed libelf libtool pkg-config
+	sudo -u $CURRENT_USER brew install gettext texinfo bison flex gnu-sed gsl gmp mpfr
 	exit
 fi
 if [ $try_port -eq 1 ]; then
-	sudo port install autoconf automake cmake doxygen gsed libelf libtool pkgconfig
+	sudo port install  gsed
 	exit
 fi

--- a/prepare-mac-os.sh
+++ b/prepare-mac-os.sh
@@ -1,0 +1,56 @@
+#!/bin/sh
+
+show_help() {
+	echo "Use '-b' or '--brew' to install packages with Homebrew, or use '-p' or '--port' to install with MacPorts."
+	echo "If left unspecified, tries Homebrew first, then MacPorts."
+	exit 1
+}
+
+if [ $# -gt 1 ]; then
+	echo "Invalid number of command line options."
+	show_help
+fi
+
+# default is autodetection
+try_brew=1
+try_port=1
+if [ $# -eq 1 ]; then
+	case "$1" in
+	-b|--brew)
+		try_port=0 ;;
+	-p|--port)
+		try_brew=0 ;;
+	*)
+		show_help ;;
+	esac
+fi
+
+if ! [ -e "/usr/local/bin/brew" -o -e "/opt/local/bin/port" ]; then
+	echo "Go install Homebrew from http://brew.sh/ or MacPorts from http://www.macports.org/ first, then we can talk!"
+	exit 1
+fi
+
+# sanity checks
+if [ $try_brew -eq 1 -a ! -e "/usr/local/bin/brew" ]; then
+	echo "Not trying Homebrew, because it is not installed."
+	try_brew=0
+fi
+if [ $try_port -eq 1 -a ! -e "/opt/local/bin/port" ]; then
+	echo "Not trying MacPorts, because it is not installed."
+	try_port=0
+fi
+if [ $try_brew -eq 0 -a $try_port -eq 0 ]; then
+	echo "Invalid package manager specified. Maybe use autodetection."
+	exit 1
+fi
+
+# actual installation
+if [ $try_brew -eq 1 ]; then
+	CURRENT_USER=$(stat -f '%Su' /dev/console)
+	sudo -u $CURRENT_USER brew install autoconf automake cmake gnu-sed libelf libtool pkg-config
+	exit
+fi
+if [ $try_port -eq 1 ]; then
+	sudo port install autoconf automake cmake doxygen gsed libelf libtool pkgconfig
+	exit
+fi

--- a/scripts/001-binutils.sh
+++ b/scripts/001-binutils.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# binutils.sh by Francisco Javier Trujillo Mata (fjtrujy@gmail.com)
+
+## Download the source code.
+REPO_URL="https://github.com/pspdev/binutils-gdb.git"
+REPO_FOLDER="binutils-gdb"
+BRANCH_NAME="allegrex-v2.23.2"
+if test ! -d "$REPO_FOLDER"; then
+	git clone --depth 1 -b $BRANCH_NAME $REPO_URL $REPO_FOLDER && cd $REPO_FOLDER || { exit 1; }
+else
+	cd $REPO_FOLDER && git fetch origin && git reset --hard origin/${BRANCH_NAME} || { exit 1; }
+fi
+
+TARGET="psp"
+TARG_XTRA_OPTS=""
+
+## Determine the maximum number of processes that Make can work with.
+PROC_NR=$(getconf _NPROCESSORS_ONLN)
+
+## Create and enter the toolchain/build directory
+rm -rf build-$TARGET && mkdir build-$TARGET && cd build-$TARGET || { exit 1; }
+
+## Configure the build.
+../configure \
+  --quiet \
+  --prefix="$PSPDEV" \
+  --target="$TARGET" \
+  --enable-plugins \
+  --disable-werror \
+  $TARG_XTRA_OPTS || { exit 1; }
+
+## Compile and install.
+make --quiet -j $PROC_NR clean || { exit 1; }
+make --quiet -j $PROC_NR MAKEINFO=true || { exit 1; }
+make --quiet -j $PROC_NR install-strip MAKEINFO=true || { exit 1; } # MAKEINFO=true for disable docs isn't compiling in Alpine
+make --quiet -j $PROC_NR clean || { exit 1; }

--- a/scripts/002-gdb.sh
+++ b/scripts/002-gdb.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# gdb.sh by Francisco Javier Trujillo Mata (fjtrujy@gmail.com)
+
+# How we're using a legacy binutils version, gdb is not include inside (it comes after 2.25)
+
+## Download the source code.
+REPO_URL="https://github.com/pspdev/binutils-gdb.git"
+REPO_FOLDER="gdb"
+BRANCH_NAME="allegrex-gdb-v7.5.1"
+if test ! -d "$REPO_FOLDER"; then
+	git clone --depth 1 -b $BRANCH_NAME $REPO_URL $REPO_FOLDER && cd $REPO_FOLDER || { exit 1; }
+else
+	cd $REPO_FOLDER && git fetch origin && git reset --hard origin/${BRANCH_NAME} || { exit 1; }
+fi
+
+TARGET="psp"
+TARG_XTRA_OPTS=""
+
+## Determine the maximum number of processes that Make can work with.
+PROC_NR=$(getconf _NPROCESSORS_ONLN)
+
+## Create and enter the toolchain/build directory
+rm -rf build-$TARGET && mkdir build-$TARGET && cd build-$TARGET || { exit 1; }
+
+## Configure the build.
+../configure \
+  --quiet \
+  --prefix="$PSPDEV" \
+  --target="$TARGET" \
+  --enable-plugins \
+  --disable-werror \
+  --disable-sim \
+  $TARG_XTRA_OPTS || { exit 1; }
+
+## Compile and install.
+make --quiet -j $PROC_NR clean || { exit 1; }
+make --quiet -j $PROC_NR CFLAGS="$CFLAGS -Wno-implicit-function-declaration" LDFLAGS="$LDFLAGS -s" || { exit 1; }
+make --quiet -j $PROC_NR install MAKEINFO=true || { exit 1; } # MAKEINFO=true for disable docs isn't compiling in Alpine
+make --quiet -j $PROC_NR clean || { exit 1; }

--- a/scripts/003-gcc-stage1.sh
+++ b/scripts/003-gcc-stage1.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# gcc-stage1.sh by Francisco Javier Trujillo Mata (fjtrujy@gmail.com)
+
+## Download the source code.
+REPO_URL="https://github.com/pspdev/gcc.git"
+REPO_FOLDER="gcc"
+BRANCH_NAME="allegrex-v9.3.0"
+if test ! -d "$REPO_FOLDER"; then
+	git clone --depth 1 -b $BRANCH_NAME $REPO_URL $REPO_FOLDER && cd $REPO_FOLDER || { exit 1; }
+else
+	cd $REPO_FOLDER && git fetch origin && git reset --hard origin/${BRANCH_NAME} || { exit 1; }
+fi
+
+TARGET="psp"
+
+OSVER=$(uname)
+## Apple needs to pretend to be linux
+if [ ${OSVER:0:6} == Darwin ]; then
+	TARG_XTRA_OPTS="--build=i386-linux-gnu --host=i386-linux-gnu"
+else
+	TARG_XTRA_OPTS=""
+fi
+
+## Determine the maximum number of processes that Make can work with.
+PROC_NR=$(getconf _NPROCESSORS_ONLN)
+
+## Create and enter the toolchain/build directory
+rm -rf mkdir build-$TARGET-stage1 && mkdir build-$TARGET-stage1 && cd build-$TARGET-stage1 || { exit 1; }
+
+## Configure the build.
+../configure \
+  --quiet \
+  --prefix="$PSPDEV" \
+  --target="$TARGET" \
+  --enable-languages="c" \
+  --with-float=hard \
+  --with-headers=no \
+  --without-newlib \
+  --disable-libssp \
+  --disable-multilib \
+  $TARG_XTRA_OPTS || { exit 1; }
+
+## Compile and install.
+make --quiet -j $PROC_NR clean          || { exit 1; }
+make --quiet -j $PROC_NR all            || { exit 1; }
+make --quiet -j $PROC_NR install-strip  || { exit 1; }
+make --quiet -j $PROC_NR clean          || { exit 1; }

--- a/scripts/003-gcc-stage1.sh
+++ b/scripts/003-gcc-stage1.sh
@@ -12,8 +12,8 @@ else
 fi
 
 TARGET="psp"
-
 OSVER=$(uname)
+
 ## Apple needs to pretend to be linux
 if [ ${OSVER:0:6} == Darwin ]; then
 	TARG_XTRA_OPTS="--build=i386-linux-gnu --host=i386-linux-gnu"

--- a/scripts/004-newlib.sh
+++ b/scripts/004-newlib.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# newlib.sh by Francisco Javier Trujillo Mata (fjtrujy@gmail.com)
+
+## Download the source code.
+REPO_URL="https://github.com/pspdev/newlib.git"
+REPO_FOLDER="newlib"
+BRANCH_NAME="allegrex-v4.1.0"
+if test ! -d "$REPO_FOLDER"; then
+	git clone --depth 1 -b $BRANCH_NAME $REPO_URL && cd $REPO_FOLDER || { exit 1; }
+else
+	cd $REPO_FOLDER && git fetch origin && git reset --hard origin/${BRANCH_NAME} && git checkout ${BRANCH_NAME} || { exit 1; }
+fi
+
+TARGET="psp"
+
+## Determine the maximum number of processes that Make can work with.
+PROC_NR=$(getconf _NPROCESSORS_ONLN)
+
+# Create and enter the toolchain/build directory
+rm -rf build-$TARGET && mkdir build-$TARGET && cd build-$TARGET || { exit 1; }
+
+# Configure the build.
+../configure \
+	--prefix="$PSPDEV" \
+	--target="$TARGET" \
+	$TARG_XTRA_OPTS || { exit 1; }
+
+## Compile and install.
+make --quiet -j $PROC_NR clean          || { exit 1; }
+make --quiet -j $PROC_NR all            || { exit 1; }
+make --quiet -j $PROC_NR install-strip  || { exit 1; }
+make --quiet -j $PROC_NR clean          || { exit 1; }

--- a/scripts/005-gcc-stage2.sh
+++ b/scripts/005-gcc-stage2.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# gcc-stage2.sh by Francisco Javier Trujillo Mata (fjtrujy@gmail.com)
+
+## Download the source code.
+REPO_URL="https://github.com/pspdev/gcc.git"
+REPO_FOLDER="gcc"
+BRANCH_NAME="allegrex-v9.3.0"
+if test ! -d "$REPO_FOLDER"; then
+	git clone --depth 1 -b $BRANCH_NAME $REPO_URL && cd $REPO_FOLDER || { exit 1; }
+else
+	cd $REPO_FOLDER && git fetch origin && git reset --hard origin/${BRANCH_NAME} || { exit 1; }
+fi
+
+TARGET="psp"
+
+OSVER=$(uname)
+## Apple needs to pretend to be linux
+if [ ${OSVER:0:6} == Darwin ]; then
+	TARG_XTRA_OPTS="--build=i386-linux-gnu --host=i386-linux-gnu"
+else
+	TARG_XTRA_OPTS=""
+fi
+
+## Determine the maximum number of processes that Make can work with.
+PROC_NR=$(getconf _NPROCESSORS_ONLN)
+
+## Create and enter the toolchain/build directory
+rm -rf build-$TARGET-stage2 && mkdir build-$TARGET-stage2 && cd build-$TARGET-stage2 || { exit 1; }
+
+## Configure the build.
+../configure \
+  --quiet \
+  --prefix="$PSPDEV" \
+  --target="$TARGET" \
+  --enable-languages="c,c++" \
+  --with-float=hard \
+  --with-newlib \
+  --disable-libssp \
+  --disable-multilib \
+  --enable-cxx-flags=-G0 \
+  $TARG_XTRA_OPTS || { exit 1; }
+
+## Compile and install.
+make --quiet -j $PROC_NR clean          || { exit 1; }
+make --quiet -j $PROC_NR all            || { exit 1; }
+make --quiet -j $PROC_NR install-strip  || { exit 1; }
+make --quiet -j $PROC_NR clean          || { exit 1; }

--- a/scripts/005-gcc-stage2.sh
+++ b/scripts/005-gcc-stage2.sh
@@ -12,8 +12,8 @@ else
 fi
 
 TARGET="psp"
-
 OSVER=$(uname)
+
 ## Apple needs to pretend to be linux
 if [ ${OSVER:0:6} == Darwin ]; then
 	TARG_XTRA_OPTS="--build=i386-linux-gnu --host=i386-linux-gnu"

--- a/toolchain-local.sh
+++ b/toolchain-local.sh
@@ -1,0 +1,11 @@
+export PSPDEV=$(pwd)/pspdev
+export PATH=$PATH:$PSPDEV/bin
+
+## If specific steps were requested...
+if [ $1 ]; then
+  ## Run the requested build scripts.
+  ./toolchain.sh $@
+else
+  ## Run the all build scripts.
+  ./toolchain.sh
+fi

--- a/toolchain-sudo.sh
+++ b/toolchain-sudo.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# toolchain-sudo.sh by Naomi Peori (naomi@peori.ca)
+ 
+ INSTALLDIR=/usr/local/pspdev
+ 
+ ## Enter the psptoolchain directory.
+ cd "`dirname $0`" || { echo "ERROR: Could not enter the psptoolchain directory."; exit 1; }
+
+ ## Set up the environment.
+ export PSPDEV=$INSTALLDIR
+ export PATH=$PATH:$PSPDEV/bin
+
+ ## Run the toolchain script.
+ ./toolchain.sh $@ || { echo "ERROR: Could not run the toolchain script."; exit 1; }

--- a/toolchain.sh
+++ b/toolchain.sh
@@ -1,40 +1,48 @@
 #!/bin/bash
-# toolchain.sh by Naomi Peori (naomi@peori.ca)
+# toolchain.sh by fjtrujy
 
- ## Load and export shared functions
- source common.sh
- export -f num_cpus
- export -f auto_extract
- export -f download_and_extract
- export -f clone_git_repo
+## Enter the pspdev directory.
+cd "$(dirname "$0")" || { echo "ERROR: Could not enter the pspdev directory."; exit 1; }
 
- ## Enter the psptoolchain directory.
- cd "`dirname $0`" || { echo "ERROR: Could not enter the psptoolchain directory."; exit 1; }
+## Create the build directory.
+mkdir -p build || { echo "ERROR: Could not create the build directory."; exit 1; }
 
- ## Create the build directory.
- mkdir -p build || { echo "ERROR: Could not create the build directory."; exit 1; }
+## Enter the build directory.
+cd build || { echo "ERROR: Could not enter the build directory."; exit 1; }
 
- ## Enter the build directory.
- cd build || { echo "ERROR: Could not enter the build directory."; exit 1; }
+## Fetch the depend scripts.
+DEPEND_SCRIPTS=($(ls ../depends/*.sh | sort))
 
- ## Fetch the depend scripts.
- DEPEND_SCRIPTS=(`ls ../depends/*.sh | sort`)
+## Run all the depend scripts.
+for SCRIPT in ${DEPEND_SCRIPTS[@]}; do "$SCRIPT" || { echo "$SCRIPT: Failed."; exit 1; } done
 
- ## Run all the depend scripts.
- for SCRIPT in ${DEPEND_SCRIPTS[@]}; do "$SCRIPT" || { echo "$SCRIPT: Failed."; exit 1; } done
+## Check if repo is in a tag, to install this specfic PSP Dev environment
+if git describe --exact-match --tags $(git log -n1 --pretty='%h') >/dev/null 2>&1; then
+  TAG=$(git describe --exact-match --tags $(git log -n1 --pretty='%h'))
+  if [ "$TAG" = "latest" ]; then
+    ## Ignore latest tag, as this tag is for service purposes only
+    echo "Installing latest environment status"
+    TAG="";
+  else
+    echo "Instaling specific version $TAG";
+  fi
+else
+  echo "Installing latest environment status"
+  TAG=""
+fi
 
- ## Fetch the build scripts.
- BUILD_SCRIPTS=(`ls ../scripts/*.sh | sort`)
+## Fetch the build scripts.
+BUILD_SCRIPTS=($(ls ../scripts/*.sh | sort))
 
- ## If specific steps were requested...
- if [ $1 ]; then
+## If specific steps were requested...
+if [ "$1" ]; then
 
   ## Run the requested build scripts.
-  for STEP in $@; do "${BUILD_SCRIPTS[$STEP-1]}" || { echo "${BUILD_SCRIPTS[$STEP-1]}: Failed."; exit 1; } done
+  for STEP in "$@"; do "${BUILD_SCRIPTS[$STEP-1]}" "$TAG" || { echo "${BUILD_SCRIPTS[$STEP-1]}: Failed."; exit 1; } done
 
- else
+else
 
   ## Run the all build scripts.
-  for SCRIPT in ${BUILD_SCRIPTS[@]}; do "$SCRIPT" || { echo "$SCRIPT: Failed."; exit 1; } done
+  for SCRIPT in ${BUILD_SCRIPTS[@]}; do "$SCRIPT" "$TAG" || { echo "$SCRIPT: Failed."; exit 1; } done
 
- fi
+fi

--- a/toolchain.sh
+++ b/toolchain.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# toolchain.sh by Naomi Peori (naomi@peori.ca)
+
+ ## Load and export shared functions
+ source common.sh
+ export -f num_cpus
+ export -f auto_extract
+ export -f download_and_extract
+ export -f clone_git_repo
+
+ ## Enter the psptoolchain directory.
+ cd "`dirname $0`" || { echo "ERROR: Could not enter the psptoolchain directory."; exit 1; }
+
+ ## Create the build directory.
+ mkdir -p build || { echo "ERROR: Could not create the build directory."; exit 1; }
+
+ ## Enter the build directory.
+ cd build || { echo "ERROR: Could not enter the build directory."; exit 1; }
+
+ ## Fetch the depend scripts.
+ DEPEND_SCRIPTS=(`ls ../depends/*.sh | sort`)
+
+ ## Run all the depend scripts.
+ for SCRIPT in ${DEPEND_SCRIPTS[@]}; do "$SCRIPT" || { echo "$SCRIPT: Failed."; exit 1; } done
+
+ ## Fetch the build scripts.
+ BUILD_SCRIPTS=(`ls ../scripts/*.sh | sort`)
+
+ ## If specific steps were requested...
+ if [ $1 ]; then
+
+  ## Run the requested build scripts.
+  for STEP in $@; do "${BUILD_SCRIPTS[$STEP-1]}" || { echo "${BUILD_SCRIPTS[$STEP-1]}: Failed."; exit 1; } done
+
+ else
+
+  ## Run the all build scripts.
+  for SCRIPT in ${BUILD_SCRIPTS[@]}; do "$SCRIPT" || { echo "$SCRIPT: Failed."; exit 1; } done
+
+ fi


### PR DESCRIPTION
## Description

This PR adds to the repository:
- The cloning and installation of `binutils`, `gdb`, `gcc` and `newlib`.
- Add CI/CD for:
1. Generating an Alpine docker layer called `psptoolchain-allegrex`
2. Testing that everything is compiling in Ubuntu, Fedora, MacOs and Windows

### MORE INFO
This PR is part of a collection of PRs, where the whole `pspdev` environment for development is being improved, with the main objectives of getting a more POSIX & Standard toolchain and integrating a CI/CD workflow to increase testability and reliability.

Others PRs related:
https://github.com/pspdev/psp-pacman/pull/15
https://github.com/pspdev/psptoolchain-extra/pull/1

Here you have more info about the new repo structures:

![layers](https://user-images.githubusercontent.com/10010409/141652593-0a666f65-c4a2-47a2-a2ac-10bde76e492f.png)

