### PR TITLE
Copy required dlls for Windows version

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -36,7 +36,7 @@ jobs:
       uses: msys2/setup-msys2@v2
       with:
         msystem: MINGW32
-        install: base-devel git make texinfo flex bison patch binutils mingw-w64-i686-gcc mingw-w64-i686-dlfcn mingw-w64-i686-mpc
+        install: git texinfo flex bison patch mingw-w64-i686-toolchain mingw-w64-i686-dlfcn
         update: true
         shell: msys2 {0}
 

--- a/depends/check-dependencies.sh
+++ b/depends/check-dependencies.sh
@@ -61,12 +61,18 @@ fi
 
 check_program   git
 
-check_program   make
+
 check_program   gcc
 check_program   g++
 
 check_program   bison
 check_program   flex
+
+if [ ${OSVER:0:5} == MINGW ]; then
+    check_program mingw32-make
+else
+    check_program make
+fi
 
 if [ -n "$(uname -a | grep Fedora)" ]; then
     check_program   cmp

--- a/scripts/001-binutils.sh
+++ b/scripts/001-binutils.sh
@@ -12,7 +12,14 @@ else
 fi
 
 TARGET="psp"
+OSVER=$(uname)
 TARG_XTRA_OPTS=""
+
+# MinGW has a different make command
+MAKE_CMD="make"
+if [ ${OSVER:0:5} == MINGW ]; then
+    MAKE_CMD="mingw32-make"
+fi
 
 ## Determine the maximum number of processes that Make can work with.
 PROC_NR=$(getconf _NPROCESSORS_ONLN)
@@ -30,10 +37,10 @@ rm -rf build-$TARGET && mkdir build-$TARGET && cd build-$TARGET || { exit 1; }
   $TARG_XTRA_OPTS || { exit 1; }
 
 ## Compile and install.
-make --quiet -j $PROC_NR clean || { exit 1; }
-make --quiet -j $PROC_NR || { exit 1; }
-make --quiet -j $PROC_NR install-strip || { exit 1; }
-make --quiet -j $PROC_NR clean || { exit 1; }
+${MAKE_CMD} --quiet -j $PROC_NR clean || { exit 1; }
+${MAKE_CMD} --quiet -j $PROC_NR || { exit 1; }
+${MAKE_CMD} --quiet -j $PROC_NR install-strip || { exit 1; }
+${MAKE_CMD} --quiet -j $PROC_NR clean || { exit 1; }
 
 ## Make sure the windows version has the required DLLs
 if [ "${OSVER:0:5}" == MINGW ]; then

--- a/scripts/001-binutils.sh
+++ b/scripts/001-binutils.sh
@@ -37,9 +37,9 @@ make --quiet -j $PROC_NR clean || { exit 1; }
 
 ## Make sure the windows version has the required DLLs
 if [ "${OSVER:0:5}" == MINGW ]; then
-	cp /usr/bin/libwinpthread-1.dll $PSPDEV/bin/
-	cp /usr/bin/libiconv-2.dll $PSPDEV/bin/
-	cp /usr/bin/libexpat-1.dll $PSPDEV/bin/
-	cp /usr/bin/libgmp-10.dll $PSPDEV/bin/
-	cp /usr/bin/libintl-8.dll $PSPDEV/bin/
+	cp /mingw64/bin/libwinpthread-1.dll $PSPDEV/bin/
+	cp /mingw64/bin/libiconv-2.dll $PSPDEV/bin/
+	cp /mingw64/bin/libexpat-1.dll $PSPDEV/bin/
+	cp /mingw64/bin/libgmp-10.dll $PSPDEV/bin/
+	cp /mingw64/bin/libintl-8.dll $PSPDEV/bin/
 fi

--- a/scripts/001-binutils.sh
+++ b/scripts/001-binutils.sh
@@ -34,3 +34,12 @@ make --quiet -j $PROC_NR clean || { exit 1; }
 make --quiet -j $PROC_NR || { exit 1; }
 make --quiet -j $PROC_NR install-strip || { exit 1; }
 make --quiet -j $PROC_NR clean || { exit 1; }
+
+## Make sure the windows version has the required DLLs
+if [ "${OSVER:0:5}" == MINGW ]; then
+	cp /usr/bin/libwinpthread-1.dll $PSPDEV/bin/
+	cp /usr/bin/libiconv-2.dll $PSPDEV/bin/
+	cp /usr/bin/libexpat-1.dll $PSPDEV/bin/
+	cp /usr/bin/libgmp-10.dll $PSPDEV/bin/
+	cp /usr/bin/libintl-8.dll $PSPDEV/bin/
+fi

--- a/scripts/002-gcc-stage1.sh
+++ b/scripts/002-gcc-stage1.sh
@@ -21,6 +21,12 @@ else
 	TARG_XTRA_OPTS=""
 fi
 
+# MinGW has a different make command
+MAKE_CMD="make"
+if [ ${OSVER:0:5} == MINGW ]; then
+    MAKE_CMD="mingw32-make"
+fi
+
 ## Determine the maximum number of processes that Make can work with.
 PROC_NR=$(getconf _NPROCESSORS_ONLN)
 
@@ -41,7 +47,7 @@ rm -rf mkdir build-$TARGET-stage1 && mkdir build-$TARGET-stage1 && cd build-$TAR
   $TARG_XTRA_OPTS || { exit 1; }
 
 ## Compile and install.
-make --quiet -j $PROC_NR clean          || { exit 1; }
-make --quiet -j $PROC_NR all            || { exit 1; }
-make --quiet -j $PROC_NR install-strip  || { exit 1; }
-make --quiet -j $PROC_NR clean          || { exit 1; }
+${MAKE_CMD} --quiet -j $PROC_NR clean          || { exit 1; }
+${MAKE_CMD} --quiet -j $PROC_NR all            || { exit 1; }
+${MAKE_CMD} --quiet -j $PROC_NR install-strip  || { exit 1; }
+${MAKE_CMD} --quiet -j $PROC_NR clean          || { exit 1; }

--- a/scripts/003-newlib.sh
+++ b/scripts/003-newlib.sh
@@ -13,6 +13,12 @@ fi
 
 TARGET="psp"
 
+# MinGW has a different make command
+MAKE_CMD="make"
+if [ "${OSVER:0:5}" == MINGW ]; then
+    MAKE_CMD="mingw32-make"
+fi
+
 ## Determine the maximum number of processes that Make can work with.
 PROC_NR=$(getconf _NPROCESSORS_ONLN)
 
@@ -26,7 +32,7 @@ rm -rf build-$TARGET && mkdir build-$TARGET && cd build-$TARGET || { exit 1; }
 	$TARG_XTRA_OPTS || { exit 1; }
 
 ## Compile and install.
-make --quiet -j $PROC_NR clean          || { exit 1; }
-make --quiet -j $PROC_NR all            || { exit 1; }
-make --quiet -j $PROC_NR install-strip  || { exit 1; }
-make --quiet -j $PROC_NR clean          || { exit 1; }
+${MAKE_CMD} --quiet -j $PROC_NR clean          || { exit 1; }
+${MAKE_CMD} --quiet -j $PROC_NR all            || { exit 1; }
+${MAKE_CMD} --quiet -j $PROC_NR install-strip  || { exit 1; }
+${MAKE_CMD} --quiet -j $PROC_NR clean          || { exit 1; }

--- a/scripts/004-gcc-stage2.sh
+++ b/scripts/004-gcc-stage2.sh
@@ -48,7 +48,7 @@ make --quiet -j $PROC_NR clean          || { exit 1; }
 
 ## Make sure the windows version has the required DLLs
 if [ "${OSVER:0:5}" == MINGW ]; then
-	cp /usr/bin/libwinpthread-1.dll $PSPDEV/bin/
-	cp /usr/bin/libiconv-2.dll $PSPDEV/bin/
-	cp /usr/bin/libintl-8.dll $PSPDEV/bin/
+	cp /mingw64/bin/libwinpthread-1.dll $PSPDEV/bin/
+	cp /mingw64/bin/libiconv-2.dll $PSPDEV/bin/
+	cp /mingw64/bin/libintl-8.dll $PSPDEV/bin/
 fi

--- a/scripts/004-gcc-stage2.sh
+++ b/scripts/004-gcc-stage2.sh
@@ -21,6 +21,12 @@ else
 	TARG_XTRA_OPTS=""
 fi
 
+# MinGW has a different make command
+MAKE_CMD="make"
+if [ "${OSVER:0:5}" == MINGW ]; then
+    MAKE_CMD="mingw32-make"
+fi
+
 ## Determine the maximum number of processes that Make can work with.
 PROC_NR=$(getconf _NPROCESSORS_ONLN)
 
@@ -41,10 +47,10 @@ rm -rf build-$TARGET-stage2 && mkdir build-$TARGET-stage2 && cd build-$TARGET-st
   $TARG_XTRA_OPTS || { exit 1; }
 
 ## Compile and install.
-make --quiet -j $PROC_NR clean          || { exit 1; }
-make --quiet -j $PROC_NR all            || { exit 1; }
-make --quiet -j $PROC_NR install-strip  || { exit 1; }
-make --quiet -j $PROC_NR clean          || { exit 1; }
+${MAKE_CMD} --quiet -j $PROC_NR clean          || { exit 1; }
+${MAKE_CMD} --quiet -j $PROC_NR all            || { exit 1; }
+${MAKE_CMD} --quiet -j $PROC_NR install-strip  || { exit 1; }
+${MAKE_CMD} --quiet -j $PROC_NR clean          || { exit 1; }
 
 ## Make sure the windows version has the required DLLs
 if [ "${OSVER:0:5}" == MINGW ]; then

--- a/scripts/004-gcc-stage2.sh
+++ b/scripts/004-gcc-stage2.sh
@@ -45,3 +45,10 @@ make --quiet -j $PROC_NR clean          || { exit 1; }
 make --quiet -j $PROC_NR all            || { exit 1; }
 make --quiet -j $PROC_NR install-strip  || { exit 1; }
 make --quiet -j $PROC_NR clean          || { exit 1; }
+
+## Make sure the windows version has the required DLLs
+if [ "${OSVER:0:5}" == MINGW ]; then
+	cp /usr/bin/libwinpthread-1.dll $PSPDEV/bin/
+	cp /usr/bin/libiconv-2.dll $PSPDEV/bin/
+	cp /usr/bin/libintl-8.dll $PSPDEV/bin/
+fi


### PR DESCRIPTION
This is still WIP. There are DLLs missing for both the compilers and the bin-utils. The issue can be fixed by either statically compiling or including the DLLs in the bin directory. I chose the latter option.