### PR TITLE
Adding support for `std:thread`

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ These scripts download (`git clone`) and install:
 -   [gdb](https://github.com/pspdev/binutils-gdb "gdb")
 -   [gcc](https://github.com/pspdev/gcc "gcc")
 -   [newlib](https://github.com/pspdev/newlib "newlib")
+-   [pthread-embedded](https://github.com/pspdev/pthread-embedded "pthread-embedded")
 
 ## Requirements
 

--- a/scripts/004-pthread-embedded.sh
+++ b/scripts/004-pthread-embedded.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# pthread-embedded.sh by Francisco Javier Trujillo Mata (fjtrujy@gmail.com)
+
+## Download the source code.
+REPO_URL="https://github.com/pspdev/pthread-embedded.git"
+REPO_FOLDER="pthread-embedded"
+BRANCH_NAME="psp"
+if test ! -d "$REPO_FOLDER"; then
+	git clone --depth 1 -b $BRANCH_NAME $REPO_URL && cd $REPO_FOLDER || { exit 1; }
+else
+	cd $REPO_FOLDER && git fetch origin && git reset --hard origin/${BRANCH_NAME} && git checkout ${BRANCH_NAME} || { exit 1; }
+fi
+
+TARGET="psp"
+
+## Determine the maximum number of processes that Make can work with.
+PROC_NR=$(getconf _NPROCESSORS_ONLN)
+
+cd platform/psp || { exit 1; }
+
+## Compile and install.
+make --quiet -j $PROC_NR clean          || { exit 1; }
+make --quiet -j $PROC_NR all            || { exit 1; }
+make --quiet -j $PROC_NR install  		|| { exit 1; }
+make --quiet -j $PROC_NR clean          || { exit 1; }

--- a/scripts/005-gcc-stage2.sh
+++ b/scripts/005-gcc-stage2.sh
@@ -38,6 +38,7 @@ rm -rf build-$TARGET-stage2 && mkdir build-$TARGET-stage2 && cd build-$TARGET-st
   --disable-libssp \
   --disable-multilib \
   --enable-cxx-flags=-G0 \
+  --enable-threads=posix \
   $TARG_XTRA_OPTS || { exit 1; }
 
 ## Compile and install.


### PR DESCRIPTION
## Description

This PR is part of a collection for the std::tread support in the PSP Toolchain

 It basically does:
- Add `pthread-embedded` to the compilation scripts.

