### PR TITLE
Add libatomic support to the toolchain

### DIFF
--- a/scripts/002-gcc-stage1.sh
+++ b/scripts/002-gcc-stage1.sh
@@ -36,6 +36,7 @@ rm -rf mkdir build-$TARGET-stage1 && mkdir build-$TARGET-stage1 && cd build-$TAR
   --with-float=hard \
   --with-headers=no \
   --without-newlib \
+  --disable-libatomic \
   --disable-libssp \
   --disable-multilib \
   $TARG_XTRA_OPTS || { exit 1; }


### PR DESCRIPTION
## Description 
It just disable the `libatomic` compilation in phase 1

This PRs needs to be merged ahead than https://github.com/pspdev/gcc/pull/3 