### PR TITLE
Build gdb without python support when build in CI

### DIFF
--- a/scripts/001-binutils.sh
+++ b/scripts/001-binutils.sh
@@ -20,12 +20,21 @@ PROC_NR=$(getconf _NPROCESSORS_ONLN)
 ## Create and enter the toolchain/build directory
 rm -rf build-$TARGET && mkdir build-$TARGET && cd build-$TARGET || { exit 1; }
 
+## Build GDB without python support when built with a GitHub Action
+## This makes the pre-build executable work on more systems
+if [ -n "$CI" ]; then
+  WITH_PYTHON="no"
+else
+  WITH_PYTHON="auto"
+fi
+
 ## Configure the build.
 ../configure \
   --quiet \
   --prefix="$PSPDEV" \
   --target="$TARGET" \
   --enable-plugins \
+  --with-python="$WITH_PYTHON" \
   --disable-werror \
   $TARG_XTRA_OPTS || { exit 1; }
 


### PR DESCRIPTION
With most Linux distributions, the psp-gdb executable shipped with the pre-build toolchain cannot be used because it is linked to a specific python version. With this change, the automated build will include a gdb executable without python support, but people who do build on their own system will have python support. I did this by checking the CI environment variable which is always set to true in GitHub Actions, but users will not have set on their machine.

Please mark this PR with the label "hacktoberfest-accepted" if it's not seen as spam. I'm hoping to get a t-shirt :D