### PR TITLE
Run weekly builds and force rebuilding everything

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,6 +6,8 @@ on:
       - main
     tags:
       - v*
+  schedule:
+    - cron: 0 17 * * 5
 
 jobs:
   build:
@@ -50,6 +52,6 @@ jobs:
     - name: Repository Dispatch
       uses: peter-evans/repository-dispatch@v1
       with:
-        repository: ${{ github.repository_owner }}/psptoolchain
+        repository: ${{ github.repository_owner }}/psptoolchain-extra
         token: ${{ secrets.DISPATCH_TOKEN }}
         event-type: ${{ env.NEW_DISPATCH_ACTION }}


### PR DESCRIPTION
With this triggering a rebuild of psptoolchain-extra, it will make sure that everything is rebuild once a week. This is because of the cascade that is set up to go all the way to psp-libraries. I set it to 17:00 on Friday, because if it breaks I'll probably be fixing it on the weekend anyway.