### PR TITLE
Use alpine 3.16 for building

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # First stage
-FROM alpine:latest
+# Please change the alpine version back to latest after 3.19 releases
+FROM alpine:3.16
 
 ENV PSPDEV /usr/local/pspdev
 ENV PATH $PATH:${PSPDEV}/bin


### PR DESCRIPTION
The gcc in alpine 3.17 and 3.18 is unfortunately broken. alpine 3.19 will have a fix, but I expect it to take another couple of months before 3.19 comes out.