### PR TITLE
Pointing to newlib 4.3.0

### DIFF
--- a/scripts/003-newlib.sh
+++ b/scripts/003-newlib.sh
@@ -4,7 +4,7 @@
 ## Download the source code.
 REPO_URL="https://github.com/pspdev/newlib.git"
 REPO_FOLDER="newlib"
-BRANCH_NAME="allegrex-v4.1.0"
+BRANCH_NAME="allegrex-v4.3.0"
 if test ! -d "$REPO_FOLDER"; then
 	git clone --depth 1 -b $BRANCH_NAME $REPO_URL && cd $REPO_FOLDER || { exit 1; }
 else

--- a/scripts/003-newlib.sh
+++ b/scripts/003-newlib.sh
@@ -23,6 +23,7 @@ rm -rf build-$TARGET && mkdir build-$TARGET && cd build-$TARGET || { exit 1; }
 ../configure \
 	--prefix="$PSPDEV" \
 	--target="$TARGET" \
+	--enable-newlib-retargetable-locking \
 	$TARG_XTRA_OPTS || { exit 1; }
 
 ## Compile and install.


### PR DESCRIPTION
I have been trying to upgrade to the latest newlib available. In this case, 4.3.0.
Additionally, I have enabled the lock API, in order to get a safer-thread environment.

You can check the changes here:
https://github.com/pspdev/newlib/commits/allegrex-v4.3.0

All the PSP-specific changes are in this small commit:
https://github.com/pspdev/newlib/commit/ef03e3aab168c4d471ef2e498c8154bff3db38c2

The remaining changes are under another commit that autogenerate the content by having proper autoconfig/automake tools after running the command autoreconf.

Cheers.