### PR TITLE
Do not build for msys2

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os[0] }}
     strategy:
       matrix:
-        os: [[macos-latest, bash], [macOS-11, bash], [ubuntu-latest, bash], [windows-latest, msys2]]
+        os: [[macos-latest, bash], [macOS-11, bash], [ubuntu-latest, bash]]
     defaults:
      run:
       shell: ${{ matrix.os[1] }} {0}
@@ -30,15 +30,6 @@ jobs:
       run: |
         brew update
         brew install gettext texinfo bison flex gnu-sed gsl gmp mpfr
-
-    - name: Install in MSYS2
-      if: matrix.os[0] == 'windows-latest'
-      uses: msys2/setup-msys2@v2
-      with:
-        msystem: MINGW32
-        install: base-devel git make texinfo flex bison patch binutils mingw-w64-i686-gcc mingw-w64-i686-dlfcn mingw-w64-i686-mpc
-        update: true
-        shell: msys2 {0}
 
     - name: Runs all stages
       run: |


### PR DESCRIPTION
This build is failing and we do not support or ship it anyway, so we should probably remove it.