### PR TITLE
Disable init/fini arrays to fix C++ constructors

### DIFF
--- a/scripts/001-binutils.sh
+++ b/scripts/001-binutils.sh
@@ -34,6 +34,7 @@ fi
   --prefix="$PSPDEV" \
   --target="$TARGET" \
   --enable-plugins \
+  --disable-initfini-array \
   --with-python="$WITH_PYTHON" \
   --disable-werror \
   $TARG_XTRA_OPTS || { exit 1; }


### PR DESCRIPTION
As it is, the support for init/fini constructors is not working (probably broken). This disables it and rolls back to ctor/dtor style runtime. This is what sdk/lib/linkfile.prx already uses, however elf_mipsallegrexel_psp.* broke due to support being enabled by default after the binutils update.

This results in .ctors/dtors sections being linked toghether again and the _start code in crt0 doing its job and initializing C++ objects. We leave the migration to init/fini arrays to the next binutils/gcc update.