### PR TITLE
Build newlib with support for C99 formatters such as %zu.

### DIFF
--- a/scripts/003-newlib.sh
+++ b/scripts/003-newlib.sh
@@ -24,6 +24,7 @@ rm -rf build-$TARGET && mkdir build-$TARGET && cd build-$TARGET || { exit 1; }
 	--prefix="$PSPDEV" \
 	--target="$TARGET" \
 	--enable-newlib-retargetable-locking \
+	--enable-newlib-io-c99-formats \
 	$TARG_XTRA_OPTS || { exit 1; }
 
 ## Compile and install.


### PR DESCRIPTION
Submitting this PR to add `--enable-newlib-io-c99-formats` to the default list of configure options, which adds support for C99 formatters such as %zu. This eases the burden of homebrew developers working on ports as they no longer need to change or write special cases to remove %zu formatters from their code. 

Consider the following sample program:
```c
#include <stdio.h>
#include <pspdebug.h>
#include <pspkernel.h>

// PSP module definition not required
// unless building formal EBOOT.PBP or PRX/KPRX.
PSP_MODULE_INFO("Hello World PSP", 0, 1, 0);

#define TEST_LOG(...) \
{\
        pspDebugScreenPrintf(__VA_ARGS__);\
        printf(__VA_ARGS__);\
}\

int main(void)
{

    TEST_LOG("Hello World!\n");
    TEST_LOG("Formatter: %zu\n", (size_t)42069);
    TEST_LOG("Formatter: %p\n", (uintptr_t)0xdeadbeef);
    TEST_LOG("Goodbye world...\n");

    while(1)
    {}

    return 0;
}
```

Compiling the toolchain normally will produce the following output from PPSSPP and from a real PSP:
![image](https://github.com/pspdev/psptoolchain-allegrex/assets/861492/961ad075-9f5d-48f8-9a46-283ed2cde14c)

Compiling the toolchain WITH the flag will result in the following correct behavior:
![image](https://github.com/pspdev/psptoolchain-allegrex/assets/861492/5fae8611-7e6a-44a9-9741-50452e4f27ca)

Recently, we also needed to patch this configure flag into the Dreamcast toolchain compilation options, as it's not enabled there either. 