### PR TITLE
fix internal compiler error in msys2 msys

### DIFF
--- a/scripts/005-gcc-stage2.sh
+++ b/scripts/005-gcc-stage2.sh
@@ -59,6 +59,7 @@ rm -rf build-$TARGET-stage2 && mkdir build-$TARGET-stage2 && cd build-$TARGET-st
   --disable-libssp \
   --disable-multilib \
   --enable-threads=posix \
+  --disable-libstdcxx-pch \
   $TARG_XTRA_OPTS || { exit 1; }
 
 ## Compile and install.


### PR DESCRIPTION
This is the error: https://pastebin.com/jHFLmRDL that I encountered when compiling the psptoolchain-allegrex scripts on the MSYS2 (MSYS) environment, and I think this PR is the most suitable. What I found out was that there was an error in the precompiled headers of the C++ standard library or something, but I'm not sure if this fix negatively affects others except the build time. I'm not a compiler expert or anything, so please enlighten me if there's an issue with my PR. Hopefully to be merged, thanks!