### PR TITLE
remove msys2 support

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -31,14 +31,6 @@ jobs:
       run: |
         brew update
         brew install gettext texinfo bison flex gnu-sed gsl gmp mpfr
-    
-    #- name: Install in MSYS2
-    #  if: matrix.os[0] == 'windows-latest'
-    #  uses: msys2/setup-msys2@v2
-    #  with:
-    #    msystem: MINGW32
-    #    install: base-devel git make texinfo flex bison patch binutils mingw-w64-i686-gcc mingw-w64-i686-dlfcn mingw-w64-i686-mpc
-    #    update: true
 
     - name: Runs all stages
       run: |

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os[0] }}
     strategy:
       matrix:
-        os: [[macos-latest, bash], [macOS-11, bash], [ubuntu-latest, bash]] # [windows-latest, msys2]]
+        os: [[macos-latest, bash], [macOS-11, bash], [ubuntu-latest, bash]]
     defaults:
      run:
       shell: ${{ matrix.os[1] }} {0}

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os[0] }}
     strategy:
       matrix:
-        os: [[macos-latest, bash], [macOS-11, bash], [ubuntu-latest, bash], [windows-latest, msys2]]
+        os: [[macos-latest, bash], [macOS-11, bash], [ubuntu-latest, bash]] # [windows-latest, msys2]]
     defaults:
      run:
       shell: ${{ matrix.os[1] }} {0}
@@ -32,13 +32,13 @@ jobs:
         brew update
         brew install gettext texinfo bison flex gnu-sed gsl gmp mpfr
     
-    - name: Install in MSYS2
-      if: matrix.os[0] == 'windows-latest'
-      uses: msys2/setup-msys2@v2
-      with:
-        msystem: MINGW32
-        install: base-devel git make texinfo flex bison patch binutils mingw-w64-i686-gcc mingw-w64-i686-dlfcn mingw-w64-i686-mpc
-        update: true
+    #- name: Install in MSYS2
+    #  if: matrix.os[0] == 'windows-latest'
+    #  uses: msys2/setup-msys2@v2
+    #  with:
+    #    msystem: MINGW32
+    #    install: base-devel git make texinfo flex bison patch binutils mingw-w64-i686-gcc mingw-w64-i686-dlfcn mingw-w64-i686-mpc
+    #    update: true
 
     - name: Runs all stages
       run: |

--- a/scripts/005-gcc-stage2.sh
+++ b/scripts/005-gcc-stage2.sh
@@ -59,7 +59,7 @@ rm -rf build-$TARGET-stage2 && mkdir build-$TARGET-stage2 && cd build-$TARGET-st
   --disable-libssp \
   --disable-multilib \
   --enable-threads=posix \
-  --disable-libstdcxx-pch \
+  # --disable-libstdcxx-pch \
   $TARG_XTRA_OPTS || { exit 1; }
 
 ## Compile and install.

--- a/scripts/005-gcc-stage2.sh
+++ b/scripts/005-gcc-stage2.sh
@@ -59,7 +59,6 @@ rm -rf build-$TARGET-stage2 && mkdir build-$TARGET-stage2 && cd build-$TARGET-st
   --disable-libssp \
   --disable-multilib \
   --enable-threads=posix \
-  # --disable-libstdcxx-pch \
   $TARG_XTRA_OPTS || { exit 1; }
 
 ## Compile and install.


### PR DESCRIPTION
- It's hard to maintain the toolchain in msys2
- I suspect this `--disable-libstdcxx-pch` is the cause of the `std::filesystem::directory_iterator` and other libstdc++ issues