### PR TITLE
Enabling multithread in newlib

### DIFF
--- a/scripts/003-newlib.sh
+++ b/scripts/003-newlib.sh
@@ -45,6 +45,7 @@ rm -rf build-$TARGET && mkdir build-$TARGET && cd build-$TARGET || { exit 1; }
 	--prefix="$PSPDEV" \
 	--target="$TARGET" \
 	--enable-newlib-retargetable-locking \
+	--enable-newlib-multithread \
 	--enable-newlib-io-c99-formats \
 	$TARG_XTRA_OPTS || { exit 1; }
 


### PR DESCRIPTION
To have thread-safe operations for all the `newlib` operations we have been required to do several PR:

- [`newlib`](https://github.com/pspdev/newlib/pull/11)
- [`psptoolchain-ee`](https://github.com/pspdev/psptoolchain-allegrex/pull/32)
- [`pspsdk`](https://github.com/pspdev/pspsdk/pull/198)

This PR skips the usage of the dummy lock API, letting us implement the specific one in the `pspsdk/libcglue`

Cheers