### PR TITLE
Enable newlib iconv

### DIFF
--- a/scripts/003-newlib.sh
+++ b/scripts/003-newlib.sh
@@ -47,6 +47,7 @@ rm -rf build-$TARGET && mkdir build-$TARGET && cd build-$TARGET || { exit 1; }
 	--enable-newlib-retargetable-locking \
 	--enable-newlib-multithread \
 	--enable-newlib-io-c99-formats \
+ 	--enable-newlib-iconv \
 	$TARG_XTRA_OPTS || { exit 1; }
 
 ## Compile and install.

--- a/scripts/003-newlib.sh
+++ b/scripts/003-newlib.sh
@@ -48,6 +48,7 @@ rm -rf build-$TARGET && mkdir build-$TARGET && cd build-$TARGET || { exit 1; }
 	--enable-newlib-multithread \
 	--enable-newlib-io-c99-formats \
  	--enable-newlib-iconv \
+  	--enable-newlib-iconv-encodings=us_ascii,utf8,utf16,ucs_2_internal,ucs_4_internal,iso_8859_1 \
 	$TARG_XTRA_OPTS || { exit 1; }
 
 ## Compile and install.


### PR DESCRIPTION
We have the headers for this but our libc doesn't actually contain the definitions. This is related to utf-8 string conversions and is built into newlib but we're not taking advantage of it.