### PR TITLE
Avoid mixing GCC stage 1 content in final toolchain

### DIFF
--- a/scripts/001-binutils.sh
+++ b/scripts/001-binutils.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# 001-binutils.sh by pspdev developers
+# binutils by pspdev developers
 
 ## Exit with code 1 when any command executed returns a non-zero exit code.
 onerr()
@@ -52,7 +52,7 @@ fi
 PROC_NR=$(getconf _NPROCESSORS_ONLN)
 
 ## Create and enter the toolchain/build directory
-rm -rf build-$TARGET && mkdir build-$TARGET && cd build-$TARGET || { exit 1; }
+rm -rf build-$TARGET && mkdir build-$TARGET && cd build-$TARGET
 
 ## Build GDB without python support when built with a GitHub Action
 ## This makes the pre-build executable work on more systems
@@ -71,10 +71,10 @@ fi
   --disable-initfini-array \
   --with-python="$WITH_PYTHON" \
   --disable-werror \
-  $TARG_XTRA_OPTS || { exit 1; }
+  $TARG_XTRA_OPTS
 
 ## Compile and install.
-make --quiet -j $PROC_NR clean || { exit 1; }
-make --quiet -j $PROC_NR || { exit 1; }
-make --quiet -j $PROC_NR install-strip || { exit 1; }
-make --quiet -j $PROC_NR clean || { exit 1; }
+make --quiet -j $PROC_NR clean
+make --quiet -j $PROC_NR all
+make --quiet -j $PROC_NR install-strip
+make --quiet -j $PROC_NR clean

--- a/scripts/001-binutils.sh
+++ b/scripts/001-binutils.sh
@@ -67,6 +67,7 @@ fi
   --quiet \
   --prefix="$PSPDEV" \
   --target="$TARGET" \
+  --with-sysroot="$PSPDEV/$TARGET" \
   --enable-plugins \
   --disable-initfini-array \
   --with-python="$WITH_PYTHON" \

--- a/scripts/003-newlib.sh
+++ b/scripts/003-newlib.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# 003-newlib.sh by pspdev developers
+# newlib by pspdev developers
 
 ## Exit with code 1 when any command executed returns a non-zero exit code.
 onerr()
@@ -7,6 +7,11 @@ onerr()
   exit 1;
 }
 trap onerr ERR
+
+## Create a temporal folder where to build the phase 1 of the toolchain.
+TMP_TOOLCHAIN_BUILD_DIR=$(pwd)/tmp_toolchain_build
+## Add the toolchain to the PATH.
+export PATH="$TMP_TOOLCHAIN_BUILD_DIR/bin:$PATH"
 
 ## Read information from the configuration file.
 source "$(dirname "$0")/../config/psptoolchain-allegrex-config.sh"
@@ -38,7 +43,7 @@ TARGET="psp"
 PROC_NR=$(getconf _NPROCESSORS_ONLN)
 
 # Create and enter the toolchain/build directory
-rm -rf build-$TARGET && mkdir build-$TARGET && cd build-$TARGET || { exit 1; }
+rm -rf build-$TARGET && mkdir build-$TARGET && cd build-$TARGET
 
 # Configure the build.
 ../configure \
@@ -49,10 +54,13 @@ rm -rf build-$TARGET && mkdir build-$TARGET && cd build-$TARGET || { exit 1; }
 	--enable-newlib-io-c99-formats \
  	--enable-newlib-iconv \
   	--enable-newlib-iconv-encodings=us_ascii,utf8,utf16,ucs_2_internal,ucs_4_internal,iso_8859_1 \
-	$TARG_XTRA_OPTS || { exit 1; }
+	$TARG_XTRA_OPTS
 
 ## Compile and install.
-make --quiet -j $PROC_NR clean          || { exit 1; }
-make --quiet -j $PROC_NR all            || { exit 1; }
-make --quiet -j $PROC_NR install-strip  || { exit 1; }
-make --quiet -j $PROC_NR clean          || { exit 1; }
+make --quiet -j $PROC_NR clean
+make --quiet -j $PROC_NR all
+make --quiet -j $PROC_NR install-strip
+make --quiet -j $PROC_NR clean
+
+## Copy contents of the toolchain to the temporal folder.
+cp -r $PSPDEV/* $TMP_TOOLCHAIN_BUILD_DIR

--- a/scripts/003-newlib.sh
+++ b/scripts/003-newlib.sh
@@ -49,6 +49,7 @@ rm -rf build-$TARGET && mkdir build-$TARGET && cd build-$TARGET
 ../configure \
 	--prefix="$PSPDEV" \
 	--target="$TARGET" \
+	--with-sysroot="$PSPDEV/$TARGET" \
 	--enable-newlib-retargetable-locking \
 	--enable-newlib-multithread \
 	--enable-newlib-io-c99-formats \

--- a/scripts/004-pthread-embedded.sh
+++ b/scripts/004-pthread-embedded.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# 004-pthread-embeedded.sh by pspdev developers
+# pthread-embeedded by pspdev developers
 
 ## Exit with code 1 when any command executed returns a non-zero exit code.
 onerr()
@@ -7,6 +7,11 @@ onerr()
   exit 1;
 }
 trap onerr ERR
+
+## Temporal folder where to build the phase 1 of the toolchain.
+TMP_TOOLCHAIN_BUILD_DIR=$(pwd)/tmp_toolchain_build
+## Add the toolchain to the PATH.
+export PATH="$TMP_TOOLCHAIN_BUILD_DIR/bin:$PATH"
 
 ## Read information from the configuration file.
 source "$(dirname "$0")/../config/psptoolchain-allegrex-config.sh"
@@ -37,10 +42,10 @@ TARGET="psp"
 ## Determine the maximum number of processes that Make can work with.
 PROC_NR=$(getconf _NPROCESSORS_ONLN)
 
-cd platform/psp || { exit 1; }
+cd platform/psp
 
 ## Compile and install.
-make --quiet -j $PROC_NR clean          || { exit 1; }
-make --quiet -j $PROC_NR all            || { exit 1; }
-make --quiet -j $PROC_NR install  		|| { exit 1; }
-make --quiet -j $PROC_NR clean          || { exit 1; }
+make --quiet -j $PROC_NR clean
+make --quiet -j $PROC_NR all
+make --quiet -j $PROC_NR install
+make --quiet -j $PROC_NR clean

--- a/scripts/005-gcc-stage2.sh
+++ b/scripts/005-gcc-stage2.sh
@@ -59,13 +59,13 @@ rm -rf build-$TARGET-stage2 && mkdir build-$TARGET-stage2 && cd build-$TARGET-st
   --prefix="$PSPDEV" \
   --target="$TARGET" \
   --with-sysroot="$PSPDEV/$TARGET" \
+  --with-native-system-header-dir="/include" \
   --enable-languages="c,c++" \
   --with-float=hard \
   --with-newlib \
   --disable-libssp \
   --disable-multilib \
   --enable-threads=posix \
-  MAKEINFO=missing \
   $TARG_XTRA_OPTS
 
 ## Compile and install.

--- a/scripts/005-gcc-stage2.sh
+++ b/scripts/005-gcc-stage2.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# 005-gcc-stage2.sh by pspdev developers
+# gcc-stage2 by pspdev developers
 
 ## Exit with code 1 when any command executed returns a non-zero exit code.
 onerr()
@@ -51,7 +51,7 @@ if [ "$(uname -s)" = "Darwin" ]; then
 fi
 
 ## Create and enter the toolchain/build directory
-rm -rf build-$TARGET-stage2 && mkdir build-$TARGET-stage2 && cd build-$TARGET-stage2 || { exit 1; }
+rm -rf build-$TARGET-stage2 && mkdir build-$TARGET-stage2 && cd build-$TARGET-stage2
 
 ## Configure the build.
 ../configure \
@@ -65,10 +65,10 @@ rm -rf build-$TARGET-stage2 && mkdir build-$TARGET-stage2 && cd build-$TARGET-st
   --disable-multilib \
   --enable-threads=posix \
   MAKEINFO=missing \
-  $TARG_XTRA_OPTS || { exit 1; }
+  $TARG_XTRA_OPTS
 
 ## Compile and install.
-make --quiet -j $PROC_NR clean          || { exit 1; }
-make --quiet -j $PROC_NR all            || { exit 1; }
-make --quiet -j $PROC_NR install-strip  || { exit 1; }
-make --quiet -j $PROC_NR clean          || { exit 1; }
+make --quiet -j $PROC_NR clean
+make --quiet -j $PROC_NR all
+make --quiet -j $PROC_NR install-strip
+make --quiet -j $PROC_NR clean

--- a/scripts/005-gcc-stage2.sh
+++ b/scripts/005-gcc-stage2.sh
@@ -58,6 +58,7 @@ rm -rf build-$TARGET-stage2 && mkdir build-$TARGET-stage2 && cd build-$TARGET-st
   --quiet \
   --prefix="$PSPDEV" \
   --target="$TARGET" \
+  --with-sysroot="$PSPDEV/$TARGET" \
   --enable-languages="c,c++" \
   --with-float=hard \
   --with-newlib \


### PR DESCRIPTION
## Description
I was trying to compile https://github.com/google/googletest for PSP and I was facing some errors when finding the `MAX_PATH` macro.

In theory the content of `MAX_PATH` is in the `limits.h` header, coming from `newlib`, however, `googletest` even including `limits.h` wasn't finding the `MAX_PATH` variable.
This was happening because we had conflicts with headers.
```
pspdev/lib/gcc/psp/14.1.0/include/limits.h
```

```
pspdev/psp/include/limits.h
```

The very first one, was the file being used when compiling `googletest`, this file shouldn't exist in our toolchain, however, the file is installed afer compiling `gcc` stage 1.

This is why I have created this PR.
The main scope of this PR is to be sure that GCC stage 1 content is shipped to a temporal folder, trying to avoid mixing it with the final content.

Additionally, other minor changes have been made.

Maybe there is a cleaner and smarter way to do this, but I couldn't find anything better.

Cheers