### PR TITLE
Use `sysroot` and `native-system-header-dir`

### DIFF
--- a/scripts/001-binutils.sh
+++ b/scripts/001-binutils.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# 001-binutils.sh by pspdev developers
+# binutils by pspdev developers
 
 ## Exit with code 1 when any command executed returns a non-zero exit code.
 onerr()
@@ -52,7 +52,7 @@ fi
 PROC_NR=$(getconf _NPROCESSORS_ONLN)
 
 ## Create and enter the toolchain/build directory
-rm -rf build-$TARGET && mkdir build-$TARGET && cd build-$TARGET || { exit 1; }
+rm -rf build-$TARGET && mkdir build-$TARGET && cd build-$TARGET
 
 ## Build GDB without python support when built with a GitHub Action
 ## This makes the pre-build executable work on more systems
@@ -67,14 +67,15 @@ fi
   --quiet \
   --prefix="$PSPDEV" \
   --target="$TARGET" \
+  --with-sysroot="$PSPDEV/$TARGET" \
   --enable-plugins \
   --disable-initfini-array \
   --with-python="$WITH_PYTHON" \
   --disable-werror \
-  $TARG_XTRA_OPTS || { exit 1; }
+  $TARG_XTRA_OPTS
 
 ## Compile and install.
-make --quiet -j $PROC_NR clean || { exit 1; }
-make --quiet -j $PROC_NR || { exit 1; }
-make --quiet -j $PROC_NR install-strip || { exit 1; }
-make --quiet -j $PROC_NR clean || { exit 1; }
+make --quiet -j $PROC_NR clean
+make --quiet -j $PROC_NR all
+make --quiet -j $PROC_NR install-strip
+make --quiet -j $PROC_NR clean

--- a/scripts/002-gcc-stage1.sh
+++ b/scripts/002-gcc-stage1.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# 002-gcc-stage1.sh by pspdev developers
+# gcc-stage1 by pspdev developers
 
 ## Exit with code 1 when any command executed returns a non-zero exit code.
 onerr()
@@ -51,7 +51,9 @@ if [ "$(uname -s)" = "Darwin" ]; then
 fi
 
 ## Create and enter the toolchain/build directory
-rm -rf mkdir build-$TARGET-stage1 && mkdir build-$TARGET-stage1 && cd build-$TARGET-stage1 || { exit 1; }
+rm -rf build-$TARGET-stage1
+mkdir build-$TARGET-stage1
+cd build-$TARGET-stage1
 
 ## Configure the build.
 ../configure \
@@ -62,13 +64,17 @@ rm -rf mkdir build-$TARGET-stage1 && mkdir build-$TARGET-stage1 && cd build-$TAR
   --with-float=hard \
   --with-headers=no \
   --without-newlib \
-  --disable-libatomic \
+  --disable-libgcc \
+  --disable-shared \
+  --disable-threads \
   --disable-libssp \
-  --disable-multilib \
-  $TARG_XTRA_OPTS || { exit 1; }
+  --disable-libgomp \
+  --disable-libmudflap \
+  --disable-libquadmath \
+  $TARG_XTRA_OPTS
 
 ## Compile and install.
-make --quiet -j $PROC_NR clean          || { exit 1; }
-make --quiet -j $PROC_NR all            || { exit 1; }
-make --quiet -j $PROC_NR install-strip  || { exit 1; }
-make --quiet -j $PROC_NR clean          || { exit 1; }
+make --quiet -j $PROC_NR clean
+make --quiet -j $PROC_NR all-gcc
+make --quiet -j $PROC_NR install-gcc
+make --quiet -j $PROC_NR clean

--- a/scripts/003-newlib.sh
+++ b/scripts/003-newlib.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# 003-newlib.sh by pspdev developers
+# newlib by pspdev developers
 
 ## Exit with code 1 when any command executed returns a non-zero exit code.
 onerr()
@@ -38,21 +38,22 @@ TARGET="psp"
 PROC_NR=$(getconf _NPROCESSORS_ONLN)
 
 # Create and enter the toolchain/build directory
-rm -rf build-$TARGET && mkdir build-$TARGET && cd build-$TARGET || { exit 1; }
+rm -rf build-$TARGET && mkdir build-$TARGET && cd build-$TARGET
 
 # Configure the build.
 ../configure \
 	--prefix="$PSPDEV" \
 	--target="$TARGET" \
+	--with-sysroot="$PSPDEV/$TARGET" \
 	--enable-newlib-retargetable-locking \
 	--enable-newlib-multithread \
 	--enable-newlib-io-c99-formats \
  	--enable-newlib-iconv \
   	--enable-newlib-iconv-encodings=us_ascii,utf8,utf16,ucs_2_internal,ucs_4_internal,iso_8859_1 \
-	$TARG_XTRA_OPTS || { exit 1; }
+	$TARG_XTRA_OPTS
 
 ## Compile and install.
-make --quiet -j $PROC_NR clean          || { exit 1; }
-make --quiet -j $PROC_NR all            || { exit 1; }
-make --quiet -j $PROC_NR install-strip  || { exit 1; }
-make --quiet -j $PROC_NR clean          || { exit 1; }
+make --quiet -j $PROC_NR clean
+make --quiet -j $PROC_NR all
+make --quiet -j $PROC_NR install-strip
+make --quiet -j $PROC_NR clean

--- a/scripts/004-pthread-embedded.sh
+++ b/scripts/004-pthread-embedded.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# 004-pthread-embeedded.sh by pspdev developers
+# pthread-embeedded by pspdev developers
 
 ## Exit with code 1 when any command executed returns a non-zero exit code.
 onerr()
@@ -37,10 +37,10 @@ TARGET="psp"
 ## Determine the maximum number of processes that Make can work with.
 PROC_NR=$(getconf _NPROCESSORS_ONLN)
 
-cd platform/psp || { exit 1; }
+cd platform/psp
 
 ## Compile and install.
-make --quiet -j $PROC_NR clean          || { exit 1; }
-make --quiet -j $PROC_NR all            || { exit 1; }
-make --quiet -j $PROC_NR install  		|| { exit 1; }
-make --quiet -j $PROC_NR clean          || { exit 1; }
+make --quiet -j $PROC_NR clean
+make --quiet -j $PROC_NR all
+make --quiet -j $PROC_NR install
+make --quiet -j $PROC_NR clean

--- a/scripts/005-gcc-stage2.sh
+++ b/scripts/005-gcc-stage2.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# 005-gcc-stage2.sh by pspdev developers
+# gcc-stage2 by pspdev developers
 
 ## Exit with code 1 when any command executed returns a non-zero exit code.
 onerr()
@@ -51,24 +51,27 @@ if [ "$(uname -s)" = "Darwin" ]; then
 fi
 
 ## Create and enter the toolchain/build directory
-rm -rf build-$TARGET-stage2 && mkdir build-$TARGET-stage2 && cd build-$TARGET-stage2 || { exit 1; }
+rm -rf build-$TARGET-stage2
+mkdir build-$TARGET-stage2
+cd build-$TARGET-stage2
 
 ## Configure the build.
 ../configure \
   --quiet \
   --prefix="$PSPDEV" \
   --target="$TARGET" \
+  --with-sysroot="$PSPDEV/$TARGET" \
+  --with-native-system-header-dir="/include" \
   --enable-languages="c,c++" \
   --with-float=hard \
   --with-newlib \
   --disable-libssp \
   --disable-multilib \
   --enable-threads=posix \
-  MAKEINFO=missing \
-  $TARG_XTRA_OPTS || { exit 1; }
+  $TARG_XTRA_OPTS
 
 ## Compile and install.
-make --quiet -j $PROC_NR clean          || { exit 1; }
-make --quiet -j $PROC_NR all            || { exit 1; }
-make --quiet -j $PROC_NR install-strip  || { exit 1; }
-make --quiet -j $PROC_NR clean          || { exit 1; }
+make --quiet -j $PROC_NR clean
+make --quiet -j $PROC_NR all
+make --quiet -j $PROC_NR install-strip
+make --quiet -j $PROC_NR clean


### PR DESCRIPTION
## Description

I was trying to compile https://github.com/google/googletest for PSP and I was facing some errors when finding the MAX_PATH macro.

Then I faced that the generated header files for GCC step 2 they weren't generated properly.
Afther some days of investigation I have been able to find out where the issue was, we missed the usage of `sysroot` and `native-system-header-dir`

I have made also some clean up in the scripts:
- Remove all the `exit 1` as we have defined the `onerr` function.
- Reduce GCC phase 1 compilation
- Other minor changes.

Once merged I will add `googletest` as dependency in `psp-packages` in this way we could at least notice in the future similar issues.

This PR deprecates the previous one https://github.com/pspdev/psptoolchain-allegrex/pull/36.

Cheers.