### PR TITLE
Create build.txt with build information

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -24,6 +24,8 @@ jobs:
       shell: ${{ matrix.os[2] }} {0}
 
     steps:
+    - uses: actions/checkout@v4
+
     - name: Install on Ubuntu
       if: matrix.os[0] == 'ubuntu-latest'
       run: |
@@ -45,8 +47,6 @@ jobs:
           base-devel git make texinfo flex bison patch binutils mingw-w64-i686-gcc mpc-devel tar
           mingw-w64-i686-cmake mingw-w64-i686-make mingw-w64-i686-libogg
         update: true
-
-    - uses: actions/checkout@v4
 
     - name: Runs all stages
       run: |
@@ -75,8 +75,6 @@ jobs:
       matrix:
         os: [[ubuntu, bash], [fedora, bash]]
     steps:
-    - uses: actions/checkout@v4
-
     - name: Install dependencies Ubuntu
       if: matrix.os[0] == 'ubuntu'
       run: |
@@ -89,7 +87,9 @@ jobs:
       run: |
         dnf -y install gcc gcc-c++ make git gettext texinfo bison flex gmp-devel mpfr-devel libmpc-devel \
           ncurses-devel diffutils glibc-gconv-extra
-        
+
+    - uses: actions/checkout@v4
+    
     - name: Runs all the stages in the shell
       run: |
         export PSPDEV=$PWD/pspdev

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -86,9 +86,12 @@ jobs:
       if: matrix.os[0] == 'fedora'
       run: |
         dnf -y install gcc gcc-c++ make git gettext texinfo bison flex gmp-devel mpfr-devel libmpc-devel \
-          ncurses-devel diffutils glibc-gconv-extra
+          ncurses-devel diffutils glibc-gconv-extra which
 
-    - uses: actions/checkout@v4
+    - make: Checkout git repo
+      uses: actions/checkout@v4
+      with:
+        set-safe-directory: true
     
     - name: Runs all the stages in the shell
       run: |

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -88,7 +88,7 @@ jobs:
         dnf -y install gcc gcc-c++ make git gettext texinfo bison flex gmp-devel mpfr-devel libmpc-devel \
           ncurses-devel diffutils glibc-gconv-extra which
 
-    - make: Checkout git repo
+    - name: Checkout git repo
       uses: actions/checkout@v4
       with:
         set-safe-directory: true

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -70,7 +70,9 @@ jobs:
 
   build-docker:
     runs-on: ubuntu-latest
-    container: ${{ matrix.os[0] }}:latest
+    container:
+      image: ${{ matrix.os[0] }}:latest
+      options: --user 1001
     strategy:
       matrix:
         os: [[ubuntu, bash], [fedora, bash]]
@@ -90,8 +92,6 @@ jobs:
 
     - name: Checkout git repo
       uses: actions/checkout@v4
-      with:
-        set-safe-directory: true
     
     - name: Runs all the stages in the shell
       run: |

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -24,8 +24,6 @@ jobs:
       shell: ${{ matrix.os[2] }} {0}
 
     steps:
-    - uses: actions/checkout@v4
-
     - name: Install on Ubuntu
       if: matrix.os[0] == 'ubuntu-latest'
       run: |
@@ -47,6 +45,8 @@ jobs:
           base-devel git make texinfo flex bison patch binutils mingw-w64-i686-gcc mpc-devel tar
           mingw-w64-i686-cmake mingw-w64-i686-make mingw-w64-i686-libogg
         update: true
+
+    - uses: actions/checkout@v4
 
     - name: Runs all stages
       run: |

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -70,9 +70,7 @@ jobs:
 
   build-docker:
     runs-on: ubuntu-latest
-    container:
-      image: ${{ matrix.os[0] }}:latest
-      options: --user 1001
+    container: ${{ matrix.os[0] }}:latest
     strategy:
       matrix:
         os: [[ubuntu, bash], [fedora, bash]]
@@ -95,6 +93,7 @@ jobs:
     
     - name: Runs all the stages in the shell
       run: |
+        chown -R $(id -nu):$(id -ng) .
         export PSPDEV=$PWD/pspdev
         export PATH=$PATH:$PSPDEV/bin
         ./toolchain.sh

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,13 +26,7 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/') != true
       run: |
         echo "DOCKER_TAG=latest" >> $GITHUB_ENV
-    
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
-      
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
-      
+
     - name: Login to Github registry
       uses: docker/login-action@v3
       with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -53,6 +53,7 @@ jobs:
     - name: Repository Dispatch
       uses: peter-evans/repository-dispatch@v2
       with:
+        context: .
         repository: ${{ github.repository_owner }}/psptoolchain-extra
         token: ${{ secrets.DISPATCH_TOKEN }}
         event-type: ${{ env.NEW_DISPATCH_ACTION }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -36,6 +36,7 @@ jobs:
     
     - uses: docker/build-push-action@v5
       with:
+        context: .
         push: true
         tags: ghcr.io/${{ github.repository }}:${{ env.DOCKER_TAG }}
     
@@ -47,7 +48,6 @@ jobs:
     - name: Repository Dispatch
       uses: peter-evans/repository-dispatch@v2
       with:
-        context: .
         repository: ${{ github.repository_owner }}/psptoolchain-extra
         token: ${{ secrets.DISPATCH_TOKEN }}
         event-type: ${{ env.NEW_DISPATCH_ACTION }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ COPY . /src
 RUN apk add build-base bash gcc git make flex bison texinfo gmp-dev mpfr-dev mpc1-dev readline-dev ncurses-dev
 RUN mkdir $PSPDEV
 RUN cd /src && ./toolchain.sh
+RUN git log -1 --format="psptoolchain-allegrex %H %cs" >> $PSPDEV/versions.txt
 
 # Second stage
 FROM alpine:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ COPY . /src
 RUN apk add build-base bash gcc git make flex bison texinfo gmp-dev mpfr-dev mpc1-dev readline-dev ncurses-dev
 RUN mkdir $PSPDEV
 RUN cd /src && ./toolchain.sh
-RUN git log -1 --format="psptoolchain-allegrex %H %cs" >> $PSPDEV/versions.txt
 
 # Second stage
 FROM alpine:latest

--- a/toolchain.sh
+++ b/toolchain.sh
@@ -52,4 +52,4 @@ BUILD_FILE="${PSPDEV}/build.txt"
 if [[ -f "${BUILD_FILE}" ]]; then
   sed -i='' '/^psptoolchain-allegrex /d' "${BUILD_FILE}"
 fi
-git log -1 --format="psptoolchain-allegrex %H %cs" >> "${BUILD_FILE}"
+git log -1 --format="psptoolchain-allegrex %H %cs %s" >> "${BUILD_FILE}"

--- a/toolchain.sh
+++ b/toolchain.sh
@@ -50,6 +50,6 @@ fi
 ## Store build information
 BUILD_FILE="${PSPDEV}/build.txt"
 if [[ -f "${BUILD_FILE}" ]]; then
-  sed -i '/^psptoolchain-allegrex /d' "${BUILD_FILE}"
+  sed -i='' '/^psptoolchain-allegrex /d' "${BUILD_FILE}"
 fi
 git log -1 --format="psptoolchain-allegrex %H %cs" >> "${BUILD_FILE}"

--- a/toolchain.sh
+++ b/toolchain.sh
@@ -47,7 +47,7 @@ else
 
 fi
 
-## Store version
+## Store build information
 BUILD_FILE="${PSPDEV}/build.txt"
 if [[ -f "${BUILD_FILE}" ]]; then
   sed -i '/^psptoolchain-allegrex /d' "${BUILD_FILE}"

--- a/toolchain.sh
+++ b/toolchain.sh
@@ -48,4 +48,5 @@ else
 fi
 
 ## Store version
-git log -1 --format="psptoolchain-allegrex %H %cs" >> $PSPDEV/versions.txt
+sed -i '/^psptoolchain-allegrex /d' $PSPDEV/build.txt
+git log -1 --format="psptoolchain-allegrex %H %cs" >> $PSPDEV/build.txt

--- a/toolchain.sh
+++ b/toolchain.sh
@@ -46,3 +46,6 @@ else
   for SCRIPT in ${BUILD_SCRIPTS[@]}; do "$SCRIPT" "$TAG" || { echo "$SCRIPT: Failed."; exit 1; } done
 
 fi
+
+## Store version
+git log -1 --format="psptoolchain-allegrex %H %cs" >> $PSPDEV/versions.txt

--- a/toolchain.sh
+++ b/toolchain.sh
@@ -48,5 +48,8 @@ else
 fi
 
 ## Store version
-sed -i '/^psptoolchain-allegrex /d' $PSPDEV/build.txt
-git log -1 --format="psptoolchain-allegrex %H %cs" >> $PSPDEV/build.txt
+BUILD_FILE="${PSPDEV}/build.txt"
+if [[ -f "${BUILD_FILE}" ]]; then
+  sed -i '/^psptoolchain-allegrex /d' "${BUILD_FILE}"
+fi
+git log -1 --format="psptoolchain-allegrex %H %cs" >> "${BUILD_FILE}"


### PR DESCRIPTION
So what this does is create the file `$PSPDEV/build.txt` which looks like this:

```
psptoolchain-allegrex 83e31058adf5d34e691393da1e6c539564f2f26a 2024-06-11
```

It will also replace that line in the build.txt file if there already is a psptoolchain-allegrex entry.

It took some fiddling to get the .git in the docker build environments, but I managed to make it work. Please squish this PR. I would like to add a PR like this for each repo in the build chain. psptoolchain will probably be the most annoying to do, since it's combining 2 repos.

Please squish this if this is merged. Most of the changes here are not useful by themselves and were me testing this change in my fork.