### PR TITLE
newlib: use `--enable-newlib-hw-fp`

### DIFF
--- a/scripts/003-newlib.sh
+++ b/scripts/003-newlib.sh
@@ -50,6 +50,7 @@ rm -rf build-$TARGET && mkdir build-$TARGET && cd build-$TARGET
 	--enable-newlib-io-c99-formats \
  	--enable-newlib-iconv \
   	--enable-newlib-iconv-encodings=us_ascii,utf8,utf16,ucs_2_internal,ucs_4_internal,iso_8859_1 \
+	--enable-newlib-hw-fp \
 	$TARG_XTRA_OPTS
 
 ## Compile and install.


### PR DESCRIPTION
I found the gcc has `--with-float` set to hard, maybe we could also use this in newlib.