### PR TITLE
CI: macos-(13 & latest): clear warnings

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -36,7 +36,7 @@ jobs:
       if: startsWith(matrix.os[0], 'macos')
       run: |
         brew update
-        brew install texinfo bison flex gnu-sed gsl gmp mpfr libmpc
+        brew install texinfo bison flex gnu-sed gsl
 
     - name: Install in MSYS2
       if: matrix.os[0] == 'windows-latest'


### PR DESCRIPTION
according to CI warnings, gmp, mpfr and libmpc are already installed. Maybe we could remove them.