### PR TITLE
Disable TLS support in gcc

### DIFF
--- a/scripts/005-gcc-stage2.sh
+++ b/scripts/005-gcc-stage2.sh
@@ -68,6 +68,7 @@ cd build-$TARGET-stage2
   --disable-libssp \
   --disable-multilib \
   --enable-threads=posix \
+  --disable-tls \
   $TARG_XTRA_OPTS
 
 ## Compile and install.


### PR DESCRIPTION
I'm still testing this, but help would be appreciated.