### PR TITLE
use `enable-target-optspace`

### DIFF
--- a/scripts/003-newlib.sh
+++ b/scripts/003-newlib.sh
@@ -50,6 +50,7 @@ rm -rf build-$TARGET && mkdir build-$TARGET && cd build-$TARGET
 	--enable-newlib-io-c99-formats \
  	--enable-newlib-iconv \
   	--enable-newlib-iconv-encodings=us_ascii,utf8,utf16,ucs_2_internal,ucs_4_internal,iso_8859_1 \
+	--enable-target-optspace \
 	$TARG_XTRA_OPTS
 
 ## Compile and install.


### PR DESCRIPTION
It helps to cutdown some roughly ~500KB to 1MB~ up to 300KB of occupied space of EBOOT.PBP.

I did some tests of samples in website and they are all working.