### PR TITLE
Force C++ 11 when building gcc

### DIFF
--- a/scripts/005-gcc-stage2.sh
+++ b/scripts/005-gcc-stage2.sh
@@ -56,6 +56,7 @@ mkdir build-$TARGET-stage2
 cd build-$TARGET-stage2
 
 ## Configure the build.
+export CXXFLAGS="-std=c++11"
 ../configure \
   --quiet \
   --prefix="$PSPDEV" \


### PR DESCRIPTION
This fixes the issue with the alpine build, since building with C++17, which is the default with the latest gcc version, causes a crash.