### PR TITLE
Revert "Force C++ 11 when building gcc"

### DIFF
--- a/scripts/005-gcc-stage2.sh
+++ b/scripts/005-gcc-stage2.sh
@@ -56,7 +56,6 @@ mkdir build-$TARGET-stage2
 cd build-$TARGET-stage2
 
 ## Configure the build.
-export CXXFLAGS="-std=c++11"
 ../configure \
   --quiet \
   --prefix="$PSPDEV" \


### PR DESCRIPTION
Reverts pspdev/psptoolchain-allegrex#51

This change ended up not being the fix, so I think we should revert it.