### PR TITLE
Build gdb without python by default

### DIFF
--- a/scripts/001-binutils.sh
+++ b/scripts/001-binutils.sh
@@ -54,13 +54,9 @@ PROC_NR=$(getconf _NPROCESSORS_ONLN)
 ## Create and enter the toolchain/build directory
 rm -rf build-$TARGET && mkdir build-$TARGET && cd build-$TARGET
 
-## Build GDB without python support when built with a GitHub Action
-## This makes the pre-build executable work on more systems
-if [ -n "$CI" ]; then
-  WITH_PYTHON="no"
-else
-  WITH_PYTHON="auto"
-fi
+## Build GDB without python support by default
+## Set the environment variable WITH_PYTHON to auto to change this
+WITH_PYTHON="${WITH_PYTHON:-no}"
 
 ## Configure the build.
 ../configure \


### PR DESCRIPTION
It is causing issues on Archlinux