### PR TITLE
compilation.yml: Use mingw64 environment

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -42,10 +42,14 @@ jobs:
       if: matrix.os[0] == 'windows-latest'
       uses: msys2/setup-msys2@v2
       with:
-        msystem: MINGW32
+        msystem: MINGW64
         install: |
-          base-devel git make texinfo flex bison patch binutils mingw-w64-i686-gcc mpc-devel tar
-          mingw-w64-i686-cmake mingw-w64-i686-make mingw-w64-i686-libogg
+          binutils bison flex patch tar git mpc-devel
+          mingw-w64-x86_64-gcc
+          mingw-w64-x86_64-autotools
+          mingw-w64-x86_64-make
+          mingw-w64-x86_64-cmake
+          mingw-w64-x86_64-texinfo
         update: true
 
     - name: Runs all stages


### PR DESCRIPTION
It's been 3 years since msys2 dropped some of their 32-bit packages and the 32-bit build of msys2 itself, maybe we could update our msys2 build CI to the latest(MINGW64 or the UCRT64). ref: https://www.msys2.org/news/#2023-12-13-starting-to-drop-some-32-bit-packages