### PR TITLE
Downgrade to Fedora 41

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -15,8 +15,8 @@ jobs:
         os: [
           [macos-latest, arm64, bash],
           [macos-13, x86_64, bash],
-          [ubuntu-latest, x86_64, bash],
-          [windows-latest, x86_64, msys2]
+          [ubuntu-latest, x86_64, bash]
+          # [windows-latest, x86_64, msys2]
         ]
       fail-fast: false
     defaults:

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -70,10 +70,10 @@ jobs:
 
   build-docker:
     runs-on: ubuntu-latest
-    container: ${{ matrix.os[0] }}:latest
+    container: ${{ matrix.os[0] }}:${{ matrix.os[2] }}
     strategy:
       matrix:
-        os: [[ubuntu, bash], [fedora, bash]]
+        os: [[ubuntu, bash, latest], [fedora, bash, 41]]
     steps:
     - name: Install dependencies Ubuntu
       if: matrix.os[0] == 'ubuntu'


### PR DESCRIPTION
Right now all our builds are failing, because building our version binutils with gcc 15 is not possible and that is the version that Fedora 42 uses. As a temporary solution until we upgrade our binutils, we should build specifically on Fedora 41 like we did before.