### PR TITLE
Fix MacOS build by requiring the use of the system's zlib

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -36,7 +36,7 @@ jobs:
       if: startsWith(matrix.os[0], 'macos')
       run: |
         brew update
-        brew install texinfo bison flex gnu-sed gsl
+        brew install texinfo bison flex gnu-sed gsl zlib
 
     - name: Install in MSYS2
       if: matrix.os[0] == 'windows-latest'

--- a/prepare-mac-os.sh
+++ b/prepare-mac-os.sh
@@ -48,7 +48,7 @@ fi
 # actual installation
 if [ $try_brew -eq 1 ]; then
 	CURRENT_USER=$(stat -f '%Su' /dev/console)
-	sudo -u $CURRENT_USER brew install gettext texinfo bison flex gnu-sed gsl gmp mpfr
+	sudo -u $CURRENT_USER brew install gettext texinfo bison flex gnu-sed gsl gmp mpfr zlib
 	exit
 fi
 if [ $try_port -eq 1 ]; then

--- a/scripts/001-binutils.sh
+++ b/scripts/001-binutils.sh
@@ -40,11 +40,11 @@ TARG_XTRA_OPTS=""
 if [ "$(uname -s)" = "Darwin" ]; then
   ## Check if using brew
   if command -v brew &> /dev/null; then
-    TARG_XTRA_OPTS="--with-gmp=$(brew --prefix gmp) --with-mpfr=$(brew --prefix mpfr)"
+    TARG_XTRA_OPTS="--with-gmp=$(brew --prefix gmp) --with-mpfr=$(brew --prefix mpfr) --with-system-zlib"
   fi
   ## Check if using MacPorts
   if command -v port &> /dev/null; then
-    TARG_XTRA_OPTS="--with-gmp=$(port -q prefix gmp) --with-mpfr=$(port -q prefix mpfr)"
+    TARG_XTRA_OPTS="--with-gmp=$(port -q prefix gmp) --with-mpfr=$(port -q prefix mpfr) --with-system-zlib"
   fi
 fi
 

--- a/scripts/002-gcc-stage1.sh
+++ b/scripts/002-gcc-stage1.sh
@@ -42,11 +42,11 @@ PROC_NR=$(getconf _NPROCESSORS_ONLN)
 if [ "$(uname -s)" = "Darwin" ]; then
   ## Check if using brew
   if command -v brew &> /dev/null; then
-    TARG_XTRA_OPTS="--with-gmp=$(brew --prefix gmp) --with-mpfr=$(brew --prefix mpfr) --with-mpc=$(brew --prefix libmpc)"
+    TARG_XTRA_OPTS="--with-gmp=$(brew --prefix gmp) --with-mpfr=$(brew --prefix mpfr) --with-mpc=$(brew --prefix libmpc) --with-system-zlib"
   fi
   ## Check if using MacPorts
   if command -v port &> /dev/null; then
-    TARG_XTRA_OPTS="--with-gmp=$(port -q prefix gmp) --with-mpfr=$(port -q prefix mpfr) --with-mpc=$(port -q prefix libmpc)"
+    TARG_XTRA_OPTS="--with-gmp=$(port -q prefix gmp) --with-mpfr=$(port -q prefix mpfr) --with-mpc=$(port -q prefix libmpc) --with-system-zlib"
   fi
 fi
 

--- a/scripts/005-gcc-stage2.sh
+++ b/scripts/005-gcc-stage2.sh
@@ -42,11 +42,11 @@ PROC_NR=$(getconf _NPROCESSORS_ONLN)
 if [ "$(uname -s)" = "Darwin" ]; then
   ## Check if using brew
   if command -v brew &> /dev/null; then
-    TARG_XTRA_OPTS="--with-gmp=$(brew --prefix gmp) --with-mpfr=$(brew --prefix mpfr) --with-mpc=$(brew --prefix libmpc)"
+    TARG_XTRA_OPTS="--with-gmp=$(brew --prefix gmp) --with-mpfr=$(brew --prefix mpfr) --with-mpc=$(brew --prefix libmpc) --with-system-zlib"
   fi
   ## Check if using MacPorts
   if command -v port &> /dev/null; then
-    TARG_XTRA_OPTS="--with-gmp=$(port -q prefix gmp) --with-mpfr=$(port -q prefix mpfr) --with-mpc=$(port -q prefix libmpc)"
+    TARG_XTRA_OPTS="--with-gmp=$(port -q prefix gmp) --with-mpfr=$(port -q prefix mpfr) --with-mpc=$(port -q prefix libmpc) --with-system-zlib"
   fi
 fi
 


### PR DESCRIPTION
With the latest version of the MacOS runner, the version of zlib bundled with gcc and binutils is no longer compatible and causes build issues. By installing zlib and using the system's zlib during compilation this problem goes away.